### PR TITLE
Automatically calculate width between "." and ":" in writing LAS files.

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -301,11 +301,12 @@ class LASFile(OrderedDictionary):
 
         # ~Version
         lines.append("~Version ".ljust(60, "-"))
-        section_widths = {
-            "left_width": None,
-            "middle_width": None
-        }
+        # section_widths = {
+        #     "left_width": None,
+        #     "middle_width": None
+        # }
         order_func = get_section_order_function("version", version)
+        section_widths = get_section_widths(self.version)
         for mnemonic, header_item in self.version.items():
             logger.debug(str(header_item))
             order = order_func(mnemonic)
@@ -316,11 +317,12 @@ class LASFile(OrderedDictionary):
 
         # ~Well
         lines.append("~Well ".ljust(60, "-"))
-        section_widths = {
-            "left_width": None,
-            "middle_width": None
-        }
+        # section_widths = {
+        #     "left_width": None,
+        #     "middle_width": None
+        # }
         order_func = get_section_order_function("well", version)
+        section_widths = get_section_widths(self.well)
         for mnemonic, header_item in self.well.items():
             order = order_func(mnemonic)
             formatter_func = get_formatter_function(order, **section_widths)
@@ -329,11 +331,12 @@ class LASFile(OrderedDictionary):
 
         # ~Curves
         lines.append("~Curves ".ljust(60, "-"))
-        section_widths = {
-            "left_width": None,
-            "middle_width": None
-        }
+        # section_widths = {
+        #     "left_width": None,
+        #     "middle_width": None
+        # }
         order_func = get_section_order_function("curves", version)
+        section_widths = get_section_widths(self.curves)
         for header_item in self.curves:
             order = order_func(header_item.mnemonic)
             formatter_func = get_formatter_function(order, **section_widths)
@@ -342,11 +345,12 @@ class LASFile(OrderedDictionary):
 
         # ~Params
         lines.append("~Params ".ljust(60, "-"))
-        section_widths = {
-            "left_width": None,
-            "middle_width": None
-        }
+        # section_widths = {
+        #     "left_width": None,
+        #     "middle_width": None
+        # }
         order_func = get_section_order_function("params", version)
+        section_widths = get_section_widths(self.params)
         for mnemonic, header_item in self.params.items():
             order = order_func(mnemonic)
             formatter_func = get_formatter_function(order, **section_widths)
@@ -766,3 +770,28 @@ def get_section_order_function(section, version,
         for mnemonic in mnemonics:
             orders[mnemonic] = order
     return lambda mnemonic: orders.get(mnemonic, default_order)
+
+
+def get_section_widths(section):
+    '''Find minimum section widths fitting the content in *section*.
+
+    Args:
+      section (dict|list): section items
+
+    '''
+    section_widths = {}
+    if isinstance(section, dict):
+        items = section.values()
+    elif isinstance(section, list):
+        items = list(section)
+
+    section_widths["left_width"] = max([len(i.mnemonic) for i in items])
+
+    descr_widths = max([len(i.descr) for i in items])
+    value_widths = max(
+        [(len(str(i.unit)) + len(str(i.value)) + 1) for i in items])
+    middle_widths = []
+    for i in range(len(descr_widths)):
+        middle_width.append(max([descr_widths[i], value_widths[i]]))
+    section_widths["middle_width"] = max(middle_widths)
+    return section_widths

--- a/lasio/test_examples/sample_write_sect_widths.las
+++ b/lasio/test_examples/sample_write_sect_widths.las
@@ -1,0 +1,46 @@
+~VERSION INFORMATION
+ VERS  .                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
+ WRAP  .                  NO:   ONE LINE PER DEPTH STEP
+~WELL INFORMATION BLOCK
+#MNEM.UNIT       DATA TYPE    INFORMATION
+#---------    -------------   ------------------------------
+ STRT.M        1670.000000:
+ STOP.M        1660.000000:
+ STEP.M            -0.1250:
+ NULLPL.           -999.2500:
+ COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ WELL.                WELL:   ANY ET AL OIL WELL #12
+ FLD .               FIELD:   EDAM
+ LOC .            LOCATION:   A9-16-49-20W3M
+ PROV.            PROVINCE:   SASKATCHEWAN
+ SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY AT ALL!!!!
+ DATE.            LOG DATE:   25-DEC-1988
+ UWI .      UNIQUE WELL ID:   100091604920W300
+~CURVE INFORMATION
+#MNEM.UNIT      API CODE      CURVE DESCRIPTION
+#---------    -------------   ------------------------------
+ DEPT.M                      :  1  DEPTH
+ DT  .US/M               :  2  SONIC TRANSIT TIME
+ RHOB.K/M3                   :  3  BULK DENSITY
+ NPHI.V/V                    :  4   NEUTRON POROSITY
+ SFLU.OHMM                   :  5  RXO RESISTIVITY
+ SFLA.OHMM                   :  6  SHALLOW RESISTIVITY
+ ILM .OHMM                   :  7  MEDIUM RESISTIVITY
+ ILD .OHMM                   :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT        VALUE       DESCRIPTION
+#---------    -------------   ------------------------------
+ BHT .DEGC         35.5000:   BOTTOM HOLE TEMPERATURE
+ BS  .MM          200.0000:   BIT SIZE
+ FD  .K/M3       1000.0000:   FLUID DENSITY
+ MATR.              0.0000:   NEUTRON MATRIX(0=LIME,1=SAND,2=DOLO)
+ MDEN.           2710.0000:   LOGGING MATRIX DENSITY
+ RMF .OHMM          0.2160:   MUD FILTRATE RESISTIVITY
+ DFD .K/M3       1525.0000:   DRILL FLUID DENSITY
+~Other
+     Note: The logging tools became stuck at 625 meters causing the data
+       between 625 meters and 615 meters to be invalid.
+~A  DEPTH     DT       RHOB     NPHI     SFLU     SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/lasio/test_examples/sample_write_sect_widths_12.las
+++ b/lasio/test_examples/sample_write_sect_widths_12.las
@@ -7,26 +7,22 @@
  STRT.M        1670.000000:
  STOP.M        1660.000000:
  STEP.M            -0.1250:
- NULLPL.           -999.2500:
- COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ NULL.           -999.2500:
+ COMPANY.             COMPANY:   # ANY OIL COMPANY LTD.
  WELL.                WELL:   ANY ET AL OIL WELL #12
  FLD .               FIELD:   EDAM
  LOC .            LOCATION:   A9-16-49-20W3M
  PROV.            PROVINCE:   SASKATCHEWAN
- SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY AT ALL!!!!
+ SRVC.     SERVICE:   The company that did this logging has a very very long name....
  DATE.            LOG DATE:   25-DEC-1988
- UWI .      UNIQUE WELL ID:   100091604920W300
+ UWI .      WELL ID:   100091604920W300
 ~CURVE INFORMATION
 #MNEM.UNIT      API CODE      CURVE DESCRIPTION
 #---------    -------------   ------------------------------
- DEPT.M                      :  1  DEPTH
- DT  .US/M               :  2  SONIC TRANSIT TIME
- RHOB.K/M3                   :  3  BULK DENSITY
- NPHI.V/V                    :  4   NEUTRON POROSITY
- SFLU.OHMM                   :  5  RXO RESISTIVITY
- SFLA.OHMM                   :  6  SHALLOW RESISTIVITY
- ILM .OHMM                   :  7  MEDIUM RESISTIVITY
- ILD .OHMM                   :  8  DEEP RESISTIVITY
+ D   .M                      :  1  DEPTH
+A  .US/M               :  2  SONIC TRANSIT TIME
+ B    .K/M3                   :  3  BULK DENSITY
+C .V/V                    :  4   NEUTRON POROSITY
 ~PARAMETER INFORMATION
 #MNEM.UNIT        VALUE       DESCRIPTION
 #---------    -------------   ------------------------------

--- a/lasio/test_examples/sample_write_sect_widths_20_narrow.las
+++ b/lasio/test_examples/sample_write_sect_widths_20_narrow.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY                              :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12                 :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       LOGGING:SERVICE COMPANY ARE YOU KIDDING THIS IS A REALLY REALLY LONG STRING
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       10012340              :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/lasio/test_examples/sample_write_sect_widths_20_wide.las
+++ b/lasio/test_examples/sample_write_sect_widths_20_wide.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       The company that did this logging has a very very long name....:SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/lasio/test_write.py
+++ b/lasio/test_write.py
@@ -9,8 +9,46 @@ test_dir = os.path.dirname(__file__)
 
 egfn = lambda fn: os.path.join(os.path.dirname(__file__), "test_examples", fn)
 
-def test_write():
-    l = read(egfn("sample_write_sect_widths.las"))
+def test_write_sect_widths_12():
+    l = read(egfn("sample_write_sect_widths_12.las"))
     s = StringIO()
     l.write(s, version=1.2)
-    
+    s.seek(0)
+    print s.read()
+
+def test_write_sect_widths_12_curves():
+    l = read(egfn("sample_write_sect_widths_12.las"))
+    s = StringIO()
+    l.write(s, version=1.2)
+    for start in ("D.M ", "A.US/M ", "B.K/M3 ", "C.V/V "):
+        s.seek(0)
+        assert "\n" + start in s.read()
+
+def test_write_sect_widths_20_narrow():
+    l = read(egfn("sample_write_sect_widths_20_narrow.las"))
+    s = StringIO()
+    l.write(s, version=2)
+    s.seek(0)
+    print s.read()
+
+def test_write_sect_widths_20_wide():
+    l = read(egfn("sample_write_sect_widths_20_wide.las"))
+    s = StringIO()
+    l.write(s, version=2)
+    s.seek(0)
+    print s.read()
+
+# def test_write_sect_widths_12_curves():
+#     l = read(egfn("sample_write_sect_widths_12.las"))
+#     s = StringIO()
+#     l.write(s, version=1.2)
+#     s.seek(0)
+#     assert """D.M                      : 1  DEPTH
+# A.US/M                   : 2  SONIC TRANSIT TIME
+# B.K/M3                   : 3  BULK DENSITY
+# C.V/V                    : 4   NEUTRON POROSITY
+# Z.OHMM                   : 5  RXO RESISTIVITY
+# E.OHMM                   : 6  SHALLOW RESISTIVITY
+# F.OHMM                   : 7  MEDIUM RESISTIVITY
+# G.OHMM                   : 8  DEEP RESISTIVITY
+# """ in s.read()

--- a/lasio/test_write.py
+++ b/lasio/test_write.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+from . import read
+from .las import StringIO
+
+test_dir = os.path.dirname(__file__)
+
+egfn = lambda fn: os.path.join(os.path.dirname(__file__), "test_examples", fn)
+
+def test_write():
+    l = read(egfn("sample_write_sect_widths.las"))
+    s = StringIO()
+    l.write(s, version=1.2)
+    

--- a/lasio/test_write.py
+++ b/lasio/test_write.py
@@ -14,7 +14,43 @@ def test_write_sect_widths_12():
     s = StringIO()
     l.write(s, version=1.2)
     s.seek(0)
-    print s.read()
+    assert s.read() == """~Version ---------------------------------------------------
+VERS.     1.2 : CWLS LOG ASCII STANDARD - VERSION 1.2
+WRAP.      NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT   .M      1670.0 : 
+STOP   .M     1669.75 : 
+STEP   .M      -0.125 : 
+NULL   .      -999.25 : 
+COMPANY.      COMPANY : # ANY OIL COMPANY LTD.
+WELL   .         WELL : ANY ET AL OIL WELL #12
+FLD    .        FIELD : EDAM
+LOC    .     LOCATION : A9-16-49-20W3M
+PROV   .     PROVINCE : SASKATCHEWAN
+SRVC   .      SERVICE : The company that did this logging has a very very long name....
+DATE   .     LOG DATE : 25-DEC-1988
+UWI    .      WELL ID : 100091604920W300
+~Curves ----------------------------------------------------
+D.M         : 1  DEPTH
+A.US/M      : 2  SONIC TRANSIT TIME
+B.K/M3      : 3  BULK DENSITY
+C.V/V       : 4   NEUTRON POROSITY
+~Params ----------------------------------------------------
+BHT .DEGC       35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM        200.0 : BIT SIZE
+FD  .K/M3     1000.0 : FLUID DENSITY
+MATR.            0.0 : NEUTRON MATRIX(0=LIME,1=SAND,2=DOLO)
+MDEN.         2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM      0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3     1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 meters causing the data
+between 625 meters and 615 meters to be invalid.
+~ASCII -----------------------------------------------------
+       1670     123.45       2550       0.45
+     1669.9     123.45       2550       0.45
+     1669.8     123.45       2550       0.45
+"""
 
 def test_write_sect_widths_12_curves():
     l = read(egfn("sample_write_sect_widths_12.las"))
@@ -29,26 +65,94 @@ def test_write_sect_widths_20_narrow():
     s = StringIO()
     l.write(s, version=2)
     s.seek(0)
-    print s.read()
+    assert s.read() == """~Version ---------------------------------------------------
+VERS.     2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.      NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M       1670.0 : START DEPTH
+STOP.M      1669.75 : STOP DEPTH
+STEP.M       -0.125 : STEP
+NULL.       -999.25 : NULL VALUE
+COMP.           ANY : COMPANY
+WELL.       AAAAA_2 : WELL
+FLD .       WILDCAT : FIELD
+LOC .            12 : LOCATION
+PROV.       ALBERTA : PROVINCE
+SRVC.       LOGGING : SERVICE COMPANY ARE YOU KIDDING THIS IS A REALLY REALLY LONG STRING
+DATE.     13-DEC-86 : LOG DATE
+UWI .      10012340 : UNIQUE WELL ID
+~Curves ----------------------------------------------------
+DEPT.M                     : 1  DEPTH
+DT  .US/M     60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3     45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V      42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM     07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM     07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM     07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM     07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .       GEL CHEM : MUD TYPE
+BHT .DEGC       35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM        200.0 : BIT SIZE
+FD  .K/M3     1000.0 : FLUID DENSITY
+MATR.           SAND : NEUTRON MATRIX
+MDEN.         2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM      0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3     1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~ASCII -----------------------------------------------------
+       1670     123.45       2550       0.45     123.45     123.45      110.2      105.6
+     1669.9     123.45       2550       0.45     123.45     123.45      110.2      105.6
+     1669.8     123.45       2550       0.45     123.45     123.45      110.2      105.6
+"""
 
 def test_write_sect_widths_20_wide():
     l = read(egfn("sample_write_sect_widths_20_wide.las"))
     s = StringIO()
     l.write(s, version=2)
     s.seek(0)
-    print s.read()
+    assert s.read() == """~Version ---------------------------------------------------
+VERS.     2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.      NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M                                                             1670.0 : START DEPTH
+STOP.M                                                            1669.75 : STOP DEPTH
+STEP.M                                                             -0.125 : STEP
+NULL.                                                             -999.25 : NULL VALUE
+COMP.                                                ANY OIL COMPANY INC. : COMPANY
+WELL.                                                             AAAAA_2 : WELL
+FLD .                                                             WILDCAT : FIELD
+LOC .                                                      12-34-12-34W5M : LOCATION
+PROV.                                                             ALBERTA : PROVINCE
+SRVC.     The company that did this logging has a very very long name.... : SERVICE COMPANY
+DATE.                                                           13-DEC-86 : LOG DATE
+UWI .                                                    100123401234W500 : UNIQUE WELL ID
+~Curves ----------------------------------------------------
+DEPT.M                     : 1  DEPTH
+DT  .US/M     60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3     45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V      42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM     07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM     07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM     07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM     07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .       GEL CHEM : MUD TYPE
+BHT .DEGC       35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM        200.0 : BIT SIZE
+FD  .K/M3     1000.0 : FLUID DENSITY
+MATR.           SAND : NEUTRON MATRIX
+MDEN.         2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM      0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3     1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~ASCII -----------------------------------------------------
+       1670     123.45       2550       0.45     123.45     123.45      110.2      105.6
+     1669.9     123.45       2550       0.45     123.45     123.45      110.2      105.6
+     1669.8     123.45       2550       0.45     123.45     123.45      110.2      105.6
+"""
 
-# def test_write_sect_widths_12_curves():
-#     l = read(egfn("sample_write_sect_widths_12.las"))
-#     s = StringIO()
-#     l.write(s, version=1.2)
-#     s.seek(0)
-#     assert """D.M                      : 1  DEPTH
-# A.US/M                   : 2  SONIC TRANSIT TIME
-# B.K/M3                   : 3  BULK DENSITY
-# C.V/V                    : 4   NEUTRON POROSITY
-# Z.OHMM                   : 5  RXO RESISTIVITY
-# E.OHMM                   : 6  SHALLOW RESISTIVITY
-# F.OHMM                   : 7  MEDIUM RESISTIVITY
-# G.OHMM                   : 8  DEEP RESISTIVITY
-# """ in s.read()

--- a/notebooks/issues/issue #4.ipynb
+++ b/notebooks/issues/issue #4.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -13,30 +13,187 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "'NULL'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-2-797dc584e03e>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mtest_write\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mtest_write\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32md:\\work\\dewnr\\logging_software\\lasio\\lasio\\test_write.pyc\u001b[0m in \u001b[0;36mtest_write\u001b[1;34m()\u001b[0m\n\u001b[0;32m     11\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     12\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0mtest_write\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 13\u001b[1;33m     \u001b[0ml\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mread\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0megfn\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"sample_write_sect_widths.las\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     14\u001b[0m     \u001b[0ms\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mStringIO\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     15\u001b[0m     \u001b[0ml\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0ms\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mversion\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m1.2\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32md:\\work\\dewnr\\logging_software\\lasio\\lasio\\__init__.pyc\u001b[0m in \u001b[0;36mread\u001b[1;34m(file_ref, encoding, autodetect_encoding, autodetect_encoding_chars)\u001b[0m\n\u001b[0;32m     24\u001b[0m     return LASFile(file_ref, encoding=encoding,\n\u001b[0;32m     25\u001b[0m                    \u001b[0mautodetect_encoding\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mautodetect_encoding\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 26\u001b[1;33m                    autodetect_encoding_chars=autodetect_encoding_chars)\n\u001b[0m",
-      "\u001b[1;32md:\\work\\dewnr\\logging_software\\lasio\\lasio\\las.pyc\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, file_ref, encoding, autodetect_encoding, autodetect_encoding_chars)\u001b[0m\n\u001b[0;32m    157\u001b[0m             self.read(file_ref, encoding=encoding,\n\u001b[0;32m    158\u001b[0m                       \u001b[0mautodetect_encoding\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mautodetect_encoding\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 159\u001b[1;33m                       autodetect_encoding_chars=autodetect_encoding_chars)\n\u001b[0m\u001b[0;32m    160\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    161\u001b[0m     def read(self, file_ref, encoding=None,\n",
-      "\u001b[1;32md:\\work\\dewnr\\logging_software\\lasio\\lasio\\las.pyc\u001b[0m in \u001b[0;36mread\u001b[1;34m(self, file_ref, encoding, autodetect_encoding, autodetect_encoding_chars)\u001b[0m\n\u001b[0;32m    224\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    225\u001b[0m         \u001b[1;31m# Set null value\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 226\u001b[1;33m         \u001b[0mreader\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mnull\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwell\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m'NULL'\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    227\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    228\u001b[0m         \u001b[0mdata\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mreader\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mread_data\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcurves\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mKeyError\u001b[0m: 'NULL'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "~Version ---------------------------------------------------\n",
+      "VERS.     1.2 : CWLS LOG ASCII STANDARD - VERSION 1.2\n",
+      "WRAP.      NO : ONE LINE PER DEPTH STEP\n",
+      "~Well ------------------------------------------------------\n",
+      "STRT   .M      1670.0 : \n",
+      "STOP   .M     1669.75 : \n",
+      "STEP   .M      -0.125 : \n",
+      "NULL   .      -999.25 : \n",
+      "COMPANY.      COMPANY : # ANY OIL COMPANY LTD.\n",
+      "WELL   .         WELL : ANY ET AL OIL WELL #12\n",
+      "FLD    .        FIELD : EDAM\n",
+      "LOC    .     LOCATION : A9-16-49-20W3M\n",
+      "PROV   .     PROVINCE : SASKATCHEWAN\n",
+      "SRVC   .      SERVICE : The company that did this logging has a very very long name....\n",
+      "DATE   .     LOG DATE : 25-DEC-1988\n",
+      "UWI    .      WELL ID : 100091604920W300\n",
+      "~Curves ----------------------------------------------------\n",
+      "D.M         : 1  DEPTH\n",
+      "A.US/M      : 2  SONIC TRANSIT TIME\n",
+      "B.K/M3      : 3  BULK DENSITY\n",
+      "C.V/V       : 4   NEUTRON POROSITY\n",
+      "~Params ----------------------------------------------------\n",
+      "BHT .DEGC       35.5 : BOTTOM HOLE TEMPERATURE\n",
+      "BS  .MM        200.0 : BIT SIZE\n",
+      "FD  .K/M3     1000.0 : FLUID DENSITY\n",
+      "MATR.            0.0 : NEUTRON MATRIX(0=LIME,1=SAND,2=DOLO)\n",
+      "MDEN.         2710.0 : LOGGING MATRIX DENSITY\n",
+      "RMF .OHMM      0.216 : MUD FILTRATE RESISTIVITY\n",
+      "DFD .K/M3     1525.0 : DRILL FLUID DENSITY\n",
+      "~Other -----------------------------------------------------\n",
+      "Note: The logging tools became stuck at 625 meters causing the data\n",
+      "between 625 meters and 615 meters to be invalid.\n",
+      "~ASCII -----------------------------------------------------\n",
+      "       1670     123.45       2550       0.45\n",
+      "     1669.9     123.45       2550       0.45\n",
+      "     1669.8     123.45       2550       0.45\n",
+      "\n"
      ]
     }
    ],
    "source": [
-    "test_write.test_write()"
+    "test_write.test_write_sect_widths_12()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "~Version ---------------------------------------------------\n",
+      "VERS.     2.0 : CWLS log ASCII Standard -VERSION 2.0\n",
+      "WRAP.      NO : ONE LINE PER DEPTH STEP\n",
+      "~Well ------------------------------------------------------\n",
+      "STRT.M       1670.0 : START DEPTH\n",
+      "STOP.M      1669.75 : STOP DEPTH\n",
+      "STEP.M       -0.125 : STEP\n",
+      "NULL.       -999.25 : NULL VALUE\n",
+      "COMP.           ANY : COMPANY\n",
+      "WELL.       AAAAA_2 : WELL\n",
+      "FLD .       WILDCAT : FIELD\n",
+      "LOC .            12 : LOCATION\n",
+      "PROV.       ALBERTA : PROVINCE\n",
+      "SRVC.       LOGGING : SERVICE COMPANY ARE YOU KIDDING THIS IS A REALLY REALLY LONG STRING\n",
+      "DATE.     13-DEC-86 : LOG DATE\n",
+      "UWI .      10012340 : UNIQUE WELL ID\n",
+      "~Curves ----------------------------------------------------\n",
+      "DEPT.M                     : 1  DEPTH\n",
+      "DT  .US/M     60 520 32 00 : 2  SONIC TRANSIT TIME\n",
+      "RHOB.K/M3     45 350 01 00 : 3  BULK DENSITY\n",
+      "NPHI.V/V      42 890 00 00 : 4  NEUTRON POROSITY\n",
+      "SFLU.OHMM     07 220 04 00 : 5  SHALLOW RESISTIVITY\n",
+      "SFLA.OHMM     07 222 01 00 : 6  SHALLOW RESISTIVITY\n",
+      "ILM .OHMM     07 120 44 00 : 7  MEDIUM RESISTIVITY\n",
+      "ILD .OHMM     07 120 46 00 : 8  DEEP RESISTIVITY\n",
+      "~Params ----------------------------------------------------\n",
+      "MUD .       GEL CHEM : MUD TYPE\n",
+      "BHT .DEGC       35.5 : BOTTOM HOLE TEMPERATURE\n",
+      "BS  .MM        200.0 : BIT SIZE\n",
+      "FD  .K/M3     1000.0 : FLUID DENSITY\n",
+      "MATR.           SAND : NEUTRON MATRIX\n",
+      "MDEN.         2710.0 : LOGGING MATRIX DENSITY\n",
+      "RMF .OHMM      0.216 : MUD FILTRATE RESISTIVITY\n",
+      "DFD .K/M3     1525.0 : DRILL FLUID DENSITY\n",
+      "~Other -----------------------------------------------------\n",
+      "Note: The logging tools became stuck at 625 metres causing the data\n",
+      "between 625 metres and 615 metres to be invalid.\n",
+      "~ASCII -----------------------------------------------------\n",
+      "       1670     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "     1669.9     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "     1669.8     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_write.test_write_sect_widths_20_narrow()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "~Version ---------------------------------------------------\n",
+      "VERS.     2.0 : CWLS log ASCII Standard -VERSION 2.0\n",
+      "WRAP.      NO : ONE LINE PER DEPTH STEP\n",
+      "~Well ------------------------------------------------------\n",
+      "STRT.M                                                             1670.0 : START DEPTH\n",
+      "STOP.M                                                            1669.75 : STOP DEPTH\n",
+      "STEP.M                                                             -0.125 : STEP\n",
+      "NULL.                                                             -999.25 : NULL VALUE\n",
+      "COMP.                                                ANY OIL COMPANY INC. : COMPANY\n",
+      "WELL.                                                             AAAAA_2 : WELL\n",
+      "FLD .                                                             WILDCAT : FIELD\n",
+      "LOC .                                                      12-34-12-34W5M : LOCATION\n",
+      "PROV.                                                             ALBERTA : PROVINCE\n",
+      "SRVC.     The company that did this logging has a very very long name.... : SERVICE COMPANY\n",
+      "DATE.                                                           13-DEC-86 : LOG DATE\n",
+      "UWI .                                                    100123401234W500 : UNIQUE WELL ID\n",
+      "~Curves ----------------------------------------------------\n",
+      "DEPT.M                     : 1  DEPTH\n",
+      "DT  .US/M     60 520 32 00 : 2  SONIC TRANSIT TIME\n",
+      "RHOB.K/M3     45 350 01 00 : 3  BULK DENSITY\n",
+      "NPHI.V/V      42 890 00 00 : 4  NEUTRON POROSITY\n",
+      "SFLU.OHMM     07 220 04 00 : 5  SHALLOW RESISTIVITY\n",
+      "SFLA.OHMM     07 222 01 00 : 6  SHALLOW RESISTIVITY\n",
+      "ILM .OHMM     07 120 44 00 : 7  MEDIUM RESISTIVITY\n",
+      "ILD .OHMM     07 120 46 00 : 8  DEEP RESISTIVITY\n",
+      "~Params ----------------------------------------------------\n",
+      "MUD .       GEL CHEM : MUD TYPE\n",
+      "BHT .DEGC       35.5 : BOTTOM HOLE TEMPERATURE\n",
+      "BS  .MM        200.0 : BIT SIZE\n",
+      "FD  .K/M3     1000.0 : FLUID DENSITY\n",
+      "MATR.           SAND : NEUTRON MATRIX\n",
+      "MDEN.         2710.0 : LOGGING MATRIX DENSITY\n",
+      "RMF .OHMM      0.216 : MUD FILTRATE RESISTIVITY\n",
+      "DFD .K/M3     1525.0 : DRILL FLUID DENSITY\n",
+      "~Other -----------------------------------------------------\n",
+      "Note: The logging tools became stuck at 625 metres causing the data\n",
+      "between 625 metres and 615 metres to be invalid.\n",
+      "~ASCII -----------------------------------------------------\n",
+      "       1670     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "     1669.9     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "     1669.8     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_write.test_write_sect_widths_20_wide()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/notebooks/issues/issue #4.ipynb
+++ b/notebooks/issues/issue #4.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from lasio import test_write"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'NULL'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-2-797dc584e03e>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mtest_write\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mtest_write\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32md:\\work\\dewnr\\logging_software\\lasio\\lasio\\test_write.pyc\u001b[0m in \u001b[0;36mtest_write\u001b[1;34m()\u001b[0m\n\u001b[0;32m     11\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     12\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0mtest_write\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 13\u001b[1;33m     \u001b[0ml\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mread\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0megfn\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"sample_write_sect_widths.las\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     14\u001b[0m     \u001b[0ms\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mStringIO\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     15\u001b[0m     \u001b[0ml\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0ms\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mversion\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m1.2\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32md:\\work\\dewnr\\logging_software\\lasio\\lasio\\__init__.pyc\u001b[0m in \u001b[0;36mread\u001b[1;34m(file_ref, encoding, autodetect_encoding, autodetect_encoding_chars)\u001b[0m\n\u001b[0;32m     24\u001b[0m     return LASFile(file_ref, encoding=encoding,\n\u001b[0;32m     25\u001b[0m                    \u001b[0mautodetect_encoding\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mautodetect_encoding\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 26\u001b[1;33m                    autodetect_encoding_chars=autodetect_encoding_chars)\n\u001b[0m",
+      "\u001b[1;32md:\\work\\dewnr\\logging_software\\lasio\\lasio\\las.pyc\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, file_ref, encoding, autodetect_encoding, autodetect_encoding_chars)\u001b[0m\n\u001b[0;32m    157\u001b[0m             self.read(file_ref, encoding=encoding,\n\u001b[0;32m    158\u001b[0m                       \u001b[0mautodetect_encoding\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mautodetect_encoding\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 159\u001b[1;33m                       autodetect_encoding_chars=autodetect_encoding_chars)\n\u001b[0m\u001b[0;32m    160\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    161\u001b[0m     def read(self, file_ref, encoding=None,\n",
+      "\u001b[1;32md:\\work\\dewnr\\logging_software\\lasio\\lasio\\las.pyc\u001b[0m in \u001b[0;36mread\u001b[1;34m(self, file_ref, encoding, autodetect_encoding, autodetect_encoding_chars)\u001b[0m\n\u001b[0;32m    224\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    225\u001b[0m         \u001b[1;31m# Set null value\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 226\u001b[1;33m         \u001b[0mreader\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mnull\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwell\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m'NULL'\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    227\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    228\u001b[0m         \u001b[0mdata\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mreader\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mread_data\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcurves\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mKeyError\u001b[0m: 'NULL'"
+     ]
+    }
+   ],
+   "source": [
+    "test_write.test_write()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
See [last comment](https://github.com/kinverarity1/lasio/issues/4#issuecomment-125108393) in #4.

This should do it.