### PR TITLE
Retain commented-out lines in header

### DIFF
--- a/lasio/test_examples/readwritecomments.las
+++ b/lasio/test_examples/readwritecomments.las
@@ -1,0 +1,40 @@
+~VERSION INFORMATION
+ VERS  .                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
+ WRAP  .                  NO:   ONE LINE PER DEPTH STEP
+~WELL INFORMATION BLOCK
+#MNEM.UNIT       DATA TYPE    INFORMATION
+#---------    -------------   ------------------------------
+ STRT.M        1670.000000:
+ STOP.M        1660.000000:
+ STEP.M            -0.1250:
+  ## BACKWARDS
+ NULL.           -999.2500:
+ COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ WELL.                WELL:   ANY ET AL OIL WELL #12
+ FLD .               FIELD:   EDAM
+# Edam field sounds like an interesting place...
+ LOC .            LOCATION:   A9-16-49-20W3M
+ PROV.            PROVINCE:   SASKATCHEWAN
+ SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY AT ALL!!!!
+# Which is strange, right?
+ DATE.            LOG DATE:   25-DEC-1988
+ UWI .      UNIQUE WELL ID:   100091604920W300
+# This unique well ID does not exist... or does it?
+# This is just to test the comment-reading/writing functionality.
+~CURVE INFORMATION
+#MNEM.UNIT      API CODE      CURVE DESCRIPTION
+#---------    -------------   ------------------------------
+ DEPT.M                      :  1  DEPTH
+ DT  .US/M               :  2  SONIC TRANSIT TIME
+ RHOB.K/M3                   :  3  BULK DENSITY
+ NPHI.V/V                    :  4   NEUTRON POROSITY
+ SFLU.OHMM                   :  5  RXO RESISTIVITY
+ SFLA.OHMM                   :  6  SHALLOW RESISTIVITY
+ ILM .OHMM                   :  7  MEDIUM RESISTIVITY
+ ILD .OHMM                   :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+~Other
+~A  DEPTH     DT       RHOB     NPHI     SFLU     SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/lasio/test_write.py
+++ b/lasio/test_write.py
@@ -164,3 +164,10 @@ between 625 metres and 615 metres to be invalid.
 def test_write_sample_empty_params():
     l = read(egfn("sample_write_empty_params.las"))
     l.write(StringIO(), version=2)
+
+def test_readwritecomments():
+    l = read(egfn("readwritecomments.las"))
+    s = StringIO()
+    l.write(s, version=2)
+    s.seek(0)
+    assert s.read() == """"""

--- a/notebooks/issues/issue #4 readwritecomments.py.ipynb
+++ b/notebooks/issues/issue #4 readwritecomments.py.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from cStringIO import StringIO\n",
+    "import lasio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "~Version ---------------------------------------------------\n",
+      "VERS.     2.0 : CWLS log ASCII Standard -VERSION 2.0\n",
+      "WRAP.      NO : ONE LINE PER DEPTH STEP\n",
+      "~Well ------------------------------------------------------\n",
+      "STRT.M                            1670.0 : \n",
+      "STOP.M                           1669.75 : \n",
+      "STEP.M                            -0.125 : \n",
+      "NULL.                            -999.25 : \n",
+      "COMP.             # ANY OIL COMPANY LTD. : COMPANY\n",
+      "WELL.             ANY ET AL OIL WELL #12 : WELL\n",
+      "FLD .                               EDAM : FIELD\n",
+      "LOC .                     A9-16-49-20W3M : LOCATION\n",
+      "PROV.                       SASKATCHEWAN : PROVINCE\n",
+      "SRVC.     ANY LOGGING COMPANY AT ALL!!!! : SERVICE COMPANY\n",
+      "DATE.                        25-DEC-1988 : LOG DATE\n",
+      "UWI .                   100091604920W300 : UNIQUE WELL ID\n",
+      "~Curves ----------------------------------------------------\n",
+      "DEPT.M         : 1  DEPTH\n",
+      "DT  .US/M      : 2  SONIC TRANSIT TIME\n",
+      "RHOB.K/M3      : 3  BULK DENSITY\n",
+      "NPHI.V/V       : 4   NEUTRON POROSITY\n",
+      "SFLU.OHMM      : 5  RXO RESISTIVITY\n",
+      "SFLA.OHMM      : 6  SHALLOW RESISTIVITY\n",
+      "ILM .OHMM      : 7  MEDIUM RESISTIVITY\n",
+      "ILD .OHMM      : 8  DEEP RESISTIVITY\n",
+      "~Params ----------------------------------------------------\n",
+      "~Other -----------------------------------------------------\n",
+      "~ASCII -----------------------------------------------------\n",
+      "       1670     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "    1669.88     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "    1669.75     123.45       2550       0.45     123.45     123.45      110.2      105.6\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "l = lasio.read(\"/home/dewnrgeophysics/software/lasio/lasio/test_examples/sample_write_empty_params.las\")\n",
+    "s = StringIO()\n",
+    "l.write(s, 2, fmt=\"%10g\")\n",
+    "s.seek(0)\n",
+    "print s.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
When reading LAS files there may be comment lines in a variety of positions in the header. Ideally `lasio` should retain these lines so that when the file is written back to disc they are placed in as close to their original position as possible.

An example is in the test suite ~Well section:

```
~WELL INFORMATION BLOCK
#MNEM.UNIT       DATA TYPE    INFORMATION
#---------    -------------   ------------------------------
 STRT.M        1670.000000:
 STOP.M        1660.000000:
 STEP.M            -0.1250:
  ## BACKWARDS
 NULL.           -999.2500:
 COMP.             COMPANY:   # ANY OIL COMPANY LTD.
 WELL.                WELL:   ANY ET AL OIL WELL #12
 FLD .               FIELD:   EDAM
# Edam field sounds like an interesting place...
 LOC .            LOCATION:   A9-16-49-20W3M
 PROV.            PROVINCE:   SASKATCHEWAN
 SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY AT ALL!!!!
# Which is strange, right?
 DATE.            LOG DATE:   25-DEC-1988
 UWI .      UNIQUE WELL ID:   100091604920W300
# This unique well ID does not exist... or does it?
# This is just to test the comment-reading/writing functionality.
~CURVE INFORMATION
#MNEM.UNIT      API CODE      CURVE DESCRIPTION
#---------    -------------   ------------------------------
 DEPT.M                      :  1  DEPTH
 DT  .US/M               :  2  SONIC TRANSIT TIME
```

I think the cleanest way to implement this is to actually read and add the lines as items in the `OrderedDictionary` for each section. This would vastly simplify writing them back out. However this ties in with plans I have been mulling over to subclass `OrderedDictionary` in order to provide a variety of things to do with the `LASFile` object (e.g. partly broken item/attribute access). It should tie in with those things.
