### PR TITLE
quickfix to write strings in ~ASCII section

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -615,10 +615,13 @@ class LASFile(object):
         nrows, ncols = data_arr.shape
 
         def format_data_section_line(n, fmt, l=10, spacer=" "):
-            if numpy.isnan(n):
-                return spacer + str(self.well["NULL"].value).rjust(l)
-            else:
-                return spacer + (fmt % n).rjust(l)
+            try:
+                if numpy.isnan(n):
+                    return spacer + str(self.well["NULL"].value).rjust(l)
+                else:
+                    return spacer + (fmt % n).rjust(l)
+            except TypeError:
+                return spacer + ('"%s"' % n).rjust(l)
 
         twrapper = textwrap.TextWrapper(width=79)
         for i in range(nrows):


### PR DESCRIPTION
I'm not that sure (haven't double check actually) if the `1.2` or `2.0` standards do something about `string` being parsed in the **~ASCII** section, but right now `lasio` is breaking if you try.

I wouldn't dare to call this a solution, so I'm calling it a (naive) quick fix for now.