### PR TITLE
Fix language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 las_reader\_version.py export-subst
+*.las linguist-vendored


### PR DESCRIPTION
GitHub linguistics identified all `*.las` files as LASSO language and added them in the statistics of the repo. This small modification in the `.gitattribute` corrects this, ignoring the `*.las` files when calculating the statistics.

*Jupyter Notebooks* are still being recognised as the majority of the files, but I imagine they would vanish as issues get solved.