### PR TITLE
Remove named list from dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # Replace dep1 dep2 ... with your dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pandas pytest requests
   - source activate test-environment
-  - pip install namedlist ordereddict cchardet argparse chardet
+  - pip install ordereddict cchardet argparse chardet
   - pip install coverage==3.7.1
   - pip install openpyxl==2.0.3
   - pip install pytest-cov coveralls

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -20,7 +20,6 @@ The recommended way to install it is from `PyPI <https://pypi.python.org/pypi/la
 
 If necessary this will download and install the packages which ``lasio`` depends on to run:
 
-- `namedlist <https://pypi.python.org/pypi/namedlist>`__ - simple and small
 - `ordereddict <https://pypi.python.org/pypi/ordereddict>`__ - simple extension to the standard library for Python 2.6 support
 - `numpy <http://numpy.org>`__ - for numerical computing, often pre-installed with scientific Python distributions
 

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -33,7 +33,6 @@ else:
 
 # Required third-party packages available on PyPi:
 
-from namedlist import namedlist
 import numpy as np
 
 # internal lasio imports

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
-namedlist
 ordereddict
 xlwt


### PR DESCRIPTION
Since namedlist is not used, it can be removed from code and as a dependency.  That may help to solve issues with insntalling lasio in latest anaconda3.  Should solve #151.