### PR TITLE
delete_curve method, unit test

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -158,11 +158,11 @@ class LASFile(object):
             file_object: a file_like object opening for writing.
             version (float): either 1.2 or 2
             wrap (bool): True, False, or None (last uses WRAP item in version)
-            STRT (float): optional override to automatic calculation using 
+            STRT (float): optional override to automatic calculation using
                 the first index curve value.
-            STOP (float): optional override to automatic calculation using 
+            STOP (float): optional override to automatic calculation using
                 the last index curve value.
-            STEP (float): optional override to automatic calculation using 
+            STEP (float): optional override to automatic calculation using
                 the first step size in the index curve.
             fmt (str): format string for numerical data being written to data
                 section.
@@ -182,7 +182,7 @@ class LASFile(object):
         Arguments:
             mnemonic (str): the name of the curve
 
-        Returns: 
+        Returns:
             A Curve object, not just the data array.
 
         '''
@@ -343,6 +343,11 @@ class LASFile(object):
             self.data = np.column_stack([data])
         curve.data = self.data[:, -1]
         self.curves.append(curve)
+
+    def delete_curve(self, mnemonic):
+        ix = self.curves.keys().index(mnemonic)
+        self.curves.pop(ix)
+        self.data = np.delete(self.data, np.s_[ix], axis=1)
 
     @property
     def header(self):

--- a/tests/test_delete_curve.py
+++ b/tests/test_delete_curve.py
@@ -1,0 +1,23 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import fnmatch
+
+import numpy as np
+import pytest
+
+from lasio import read
+
+test_dir = os.path.dirname(__file__)
+
+egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+stegfn = lambda vers, fn: os.path.join(
+    os.path.dirname(__file__), "examples", vers, fn)
+
+def test_delete_curve():
+    l = read(egfn("sample.las"))
+    shape = l.data.shape[1]
+    curve = l.curves.keys()[1]
+    l.delete_curve(curve)
+    assert curve not in l.curves.keys()
+    assert len(l.curves.keys()) == (shape - 1)
+    assert l.curves.keys() == ['DEPT', 'RHOB', 'NPHI', 'SFLU', 'SFLA','ILM', 'ILD']


### PR DESCRIPTION
Added a method for deleting a curve from a LASFile object. First gets the index in the `curves.keys()` list of the curve argument, then deletes the corresponding CurveItem from the `curves` attribute, then deletes the corresponding "column" in the ndarray `data` attribute. Also added a test-- hopefully it is up to snuff.

Apologies about the STRT, STOP, STEP, and Returns lines. My text editor must have automatically removed trailing spaces.