### PR TITLE
Add cases for WRAP and continue scan lines if not match with pattern

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -123,7 +123,13 @@ class LASFile(object):
                 read_parser.version = 1.2
             else:
                 read_parser.version = 2
-        read_parser.wrap = self.version['WRAP'].value == 'YES'
+
+        for key in self.version.keys():
+            if key.lower() == 'wrap':
+                read_parser.wrap = self.version[key].value == 'YES'
+                break
+        else:
+            raise KeyError('No key WRAP in ~V section')
 
         self.sections['Well'] = read_parser.read_section('~W')
         self.sections['Curves'] = read_parser.read_section('~C')

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -139,6 +139,7 @@ class Reader(object):
         for line in self.iter_section_lines(section_name):
             try:
                 values = read_line(line)
+                if values is None: continue
             except:
                 raise exceptions.LASHeaderError(
                     'Failed in %s section on line:\n%s%s' % (
@@ -300,6 +301,7 @@ def read_line(line, pattern=None):
                    r'(?P<value>[^:]*):' +
                    r'(?P<descr>.*)')
     m = re.match(pattern, line)
+    if not m: return None
     mdict = m.groupdict()
     # if mdict['name'] == '':
     #     mdict['name'] = 'UNKNOWN'


### PR DESCRIPTION
Continue scanning lines if not match with pattern to avoid stopping running when some lines don't match the pattern that doesn't effect the whole file.