### PR TITLE
Iterative read v2

### DIFF
--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -27,6 +27,9 @@ def read(file_ref, **kwargs):
             a LAS file contents.
 
     Keyword Arguments:
+        ignore_data (bool): if True, do not read in any of the actual data, just
+            the header metadata. False by default.
+        ignore_header_errors (bool): ignore lASHeaderErrors: False by default
         encoding (str): character encoding to open file_ref with
         encoding_errors (str): 'strict', 'replace' (default), 'ignore' - how to
             handle errors with encodings (see standard library codecs module or

--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -1,3 +1,4 @@
+import re
 
 import numpy as np
 
@@ -56,3 +57,9 @@ ORDER_DEFINITIONS = {
 
 FEET_UNITS = ("FT", "F", "FEET", "FOOT")
 METRE_UNITS = ("M", "METER", "METERS", "METRE", "METRES")
+
+SUB_PATTERNS = [
+    (re.compile(r'(\d)-(\d)'), r'\1 -\2'),
+    (re.compile('-?\d*\.\d*\.\d*'), ' NaN NaN '),
+    (re.compile('NaN.\d*'), ' NaN NaN '),
+    ]

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -99,9 +99,7 @@ class LASFile(object):
         '''
 
         file_obj = reader.open_file(file_ref, **kwargs)
-        self._text = file_obj.read()
-
-        # Temporary only
+        self._raw_sections = reader.read_file_contents(file_obj, null_subs=null_subs)
         if hasattr(file_obj, "close"):
             file_obj.close()
 

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -98,11 +98,12 @@ class LASFile(object):
 
         '''
 
-        self._file_obj = reader.open_file(file_ref, **kwargs)
-        self._file_ref = str(file_ref)
+        file_obj = reader.open_file(file_ref, **kwargs)
+        self._text = file_obj.read()
 
-        self._text = self._file_obj.read()
-        logger.debug('LASFile.read LAS content is type %s' % type(self._text))
+        # Temporary only
+        if hasattr(file_obj, "close"):
+            file_obj.close()
 
         read_parser = reader.Reader(self._text, version=1.2)
         self.sections['Version'] = read_parser.read_section('~V')

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -170,7 +170,15 @@ class LASFile(object):
                 arr = s["array"]
                 if null_subs:
                     arr[arr == null] = np.nan
-                data = np.reshape(arr, (-1, len(self.curves)))
+
+                n_curves = len(self.curves)
+                n_arr_cols = len(self.curves) # provisional pending below check
+                logger.debug("n_curves=%d ncols=%d" % (n_curves, s["ncols"]))
+                if self.version["WRAP"].value == "NO":
+                    if s["ncols"] > n_curves:
+                        n_arr_cols = s["ncols"]
+                data = np.reshape(arr, (-1, n_arr_cols))
+
                 self.set_data(data, truncate=False)
                 drop.append(s["title"])
             else:

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -115,10 +115,10 @@ class LASFile(object):
             if raw_section:
                 self.sections[name] = reader.parse_header_section(raw_section, **sect_kws)
                 drop.append(raw_section["title"])
-            for key in drop:
-                self.raw_sections.pop(key)
             else:
                 logger.warning("Header section %s regexp=%s was not found." % (name, pattern))
+            for key in drop:
+                self.raw_sections.pop(key)
 
         add_section("~V", "Version", version=1.2, ignore_header_errors=ignore_header_errors)
 

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -105,7 +105,7 @@ class LASFile(object):
         '''
 
         file_obj = reader.open_file(file_ref, **kwargs)
-        self.raw_sections = reader.read_file_contents(file_obj, null_subs=null_subs, ignore_data=ignore_data)
+        self.raw_sections = reader.read_file_contents(file_obj, ignore_data=ignore_data)
         if hasattr(file_obj, "close"):
             file_obj.close()
 

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -97,7 +97,7 @@ def open_file(file_ref, encoding=None, encoding_errors='replace',
     return file_ref
 
 
-def read_file_contents(file_obj, null_subs=True):
+def read_file_contents(file_obj, null_subs=True, ignore_data=False):
     '''Read file contents into memory.
 
     Arguments:
@@ -105,6 +105,7 @@ def read_file_contents(file_obj, null_subs=True):
 
     Keyword Arguments:
         null_subs (bool???): ????
+        ignore_data (bool): do not read in the numerical data in the ~ASCII section
 
     Returns: 
         An ordered dictionary with keys being the first line of each
@@ -146,12 +147,14 @@ def read_file_contents(file_obj, null_subs=True):
                 "lines": sect_lines,
                 "line_nos": sect_line_nos,
                 }
-            data, n_range = read_numerical_file_contents(file_obj, i, null_subs)
-            sections[line] = {
-                "section_types": "data",
-                "title": line,
-                "array": data,
-                "line_nos_range": n_range}
+            if not ignore_data:
+                data, n_range = read_numerical_file_contents(file_obj, i, null_subs)
+                sections[line] = {
+                    "section_types": "data",
+                    "title": line,
+                    "array": data,
+                    "line_nos_range": n_range}
+            break
 
         elif line.startswith('~'):
             if sect_lines:
@@ -222,6 +225,11 @@ def parse_header_section(sectdict, version):
                     traceback.format_exc().splitlines()[-1]))
         else:
             section.append(parser(**values))
+    return section
+
+
+
+
 
 
 class Reader(object):

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -240,17 +240,9 @@ def read_file_contents(file_obj, ignore_data=False):
                 }
             if not ignore_data:
                 data = read_numerical_file_contents(file_obj, i + 1)
-                # file_obj.seek(0)
-                # for j, line in enumerate(file_obj):
-                #     if j == (i + 1):
-                #         for pattern, sub_str in defaults.SUB_PATTERNS:
-                #             line = re.sub(pattern, sub_str, line)
-                #         ncols = len(line.split())
-                #         break
-
                 sections[line] = {
                     "section_type": "data",
-                    # "start_line": j,
+                    "start_line": i,
                     # "ncols": ncols,
                     "title": line,
                     "array": data,
@@ -278,6 +270,19 @@ def read_file_contents(file_obj, ignore_data=False):
             if not line.startswith("#"):       # ignore commented-out lines.. for now.
                 sect_lines.append(line)
                 sect_line_nos.append(i + 1)
+
+    # Find the number of columns in the data section(s). This is only 
+    # useful is WRAP = NO, but we do it for all since we don't yet know
+    # what the wrap setting is.
+    for section in sections.values():
+        if section["section_type"] == "data":
+            file_obj.seek(0)
+            for i, line in enumerate(file_obj):
+                if i == section["start_line"] + 1:
+                    for pattern, sub_str in defaults.SUB_PATTERNS:
+                        line = re.sub(pattern, sub_str, line)
+                    section["ncols"] = len(line.split())
+                    break
     return sections
 
 

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -78,7 +78,8 @@ def open_file(file_ref,
         if URL_REGEXP.match(first_line): # it's a URL
             try:
                 import urllib2
-                file_ref = urllib2.urlopen(first_line)
+                url_ref = urllib2.urlopen(first_line)
+                file_ref = StringIO(url_ref.read())
             except ImportError:
                 import urllib.request
                 response = urllib.request.urlopen(file_ref)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -58,6 +58,9 @@ def test_dodgy_param_sect():
     with pytest.raises(exceptions.LASHeaderError):
         l = read(egfn("dodgy_param_sect.las"))
 
+def test_ignore_header_errors():
+    l = read(egfn("dodgy_param_sect.las"), ignore_header_errors=True)
+
 def test_mnemonic_good():
     l = read(egfn("mnemonic_good.las"))
     assert [c.mnemonic for c in l.curves] == [

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -6,6 +6,7 @@ import numpy
 import pytest
 
 from lasio import read
+from lasio import exceptions
 
 test_dir = os.path.dirname(__file__)
 
@@ -54,8 +55,8 @@ def test_read_v2_sample_wrapped():
 
 
 def test_dodgy_param_sect():
-    l = read(egfn("dodgy_param_sect.las"))
-
+    with pytest.raises(exceptions.LASHeaderError):
+        l = read(egfn("dodgy_param_sect.las"))
 
 def test_mnemonic_good():
     l = read(egfn("mnemonic_good.las"))

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -66,7 +66,6 @@ def test_mnemonic_good():
     assert [c.mnemonic for c in l.curves] == [
         "DEPT", "DT", "RHOB", "NPHI", "SFLU", "SFLA", "ILM", "ILD"]
 
-
 def test_mnemonic_duplicate():
     l = read(egfn("mnemonic_duplicate.las"))
     assert [c.mnemonic for c in l.curves] == [


### PR DESCRIPTION
This long-overdue PR implements an iterative read. Instead of reading the whole LAS file into memory, ``reader.py`` now looks at the file only line by line - the number of passes has gone from who knows how many to a maximum of 1 + n, where n is the number of data sections.

There are two new features:

1. ``lasio.read`` has a new keyword argument ``ignore_data`` (thanks @dagrha for [suggesting this](discussion)). If this is True, then lasio will not read the file beyond the start of the ~ASCII data section. Attempting to use the ``LASFile.data`` attribute, or any methods that use it (many!) will raise an ``AttributeError``.
2. ``lasio.read`` also has a new keyword argument ``ignore_header_errors``. Anything that would have raised a exception (``lasio.exceptions.LASHeaderError``) will instead result in the same message being sent to ``logging.debug`` and ignored. The remaining parts of the header should successfully be parsed and loaded.
    (Note this involved changing one unit test, so you may need to change production code to accommodate this with ``ignore_header_errors=True`` if have any poorly-formatted header lines in the Parameter section. It is set to False by default.)

And performance improvements ([benchmarking code and results](https://github.com/kinverarity1/lasio-speed)):

- Memory usage. For an example 5 MB LAS file, the memory usage has gone from [30 MB](https://github.com/kinverarity1/lasio-speed/blob/master/result-3b47a23.txt#L16) to [3.3 MB](https://github.com/kinverarity1/lasio-speed/blob/master/result-4d6678c.txt#L16). 
- Speed. For the same example, load time went from [7.6 s](https://github.com/kinverarity1/lasio-speed/blob/master/result-3b47a23.txt#L19) to [1.9 s](https://github.com/kinverarity1/lasio-speed/blob/master/result-4d6678c.txt#L19) on my machine. Still not great, but much better than it was.