### PR TITLE
Issue155 delete header item

### DIFF
--- a/lasio/las_items.py
+++ b/lasio/las_items.py
@@ -256,6 +256,23 @@ class SectionItems(list):
         else:
             raise KeyError('%s not in %s' % (key, self.keys()))
 
+    def __delitem__(self, key):
+        '''Delete item by either mnemonic or index.
+
+        Arguments:
+            key (str, int): either a mnemonic or the index to the list.
+
+        '''
+        for ix, item in enumerate(self):
+            if item.mnemonic == key:
+                super(SectionItems, self).__delitem__(ix)
+                return
+        if isinstance(key, int):
+            super(SectionItems, self).__delitem__(key)
+            return
+        else:
+            raise KeyError('%s not in %s' % (key, self.keys()))
+
     def __setitem__(self, key, newitem):
         '''Either replace the item or its value.
 

--- a/tests/test_delete_curve.py
+++ b/tests/test_delete_curve.py
@@ -5,7 +5,7 @@ import fnmatch
 import numpy as np
 import pytest
 
-from lasio import read
+import lasio
 
 test_dir = os.path.dirname(__file__)
 
@@ -14,10 +14,15 @@ stegfn = lambda vers, fn: os.path.join(
     os.path.dirname(__file__), "examples", vers, fn)
 
 def test_delete_curve():
-    l = read(egfn("sample.las"))
+    l = lasio.read(egfn("sample.las"))
     shape = l.data.shape[1]
     curve = l.curves.keys()[1]
     l.delete_curve(curve)
     assert curve not in l.curves.keys()
     assert len(l.curves.keys()) == (shape - 1)
     assert l.curves.keys() == ['DEPT', 'RHOB', 'NPHI', 'SFLU', 'SFLA','ILM', 'ILD']
+
+def test_delete_section_item():
+    las = lasio.read(egfn('sample.las'))
+    del las.params['MDEN']
+    assert las.params.keys() == ['BHT', 'BS', 'FD', 'MATR', 'RMF', 'DFD']

--- a/tests/test_delete_items.py
+++ b/tests/test_delete_items.py
@@ -22,7 +22,12 @@ def test_delete_curve():
     assert len(l.curves.keys()) == (shape - 1)
     assert l.curves.keys() == ['DEPT', 'RHOB', 'NPHI', 'SFLU', 'SFLA','ILM', 'ILD']
 
-def test_delete_section_item():
+def test_delete_section_item_by_index():
+    las = lasio.read(egfn('sample.las'))
+    del las.params[1]
+    assert las.params.keys() == ['BHT', 'FD', 'MATR', 'MDEN', 'RMF', 'DFD']
+
+def test_delete_section_item_by_mnemonic():
     las = lasio.read(egfn('sample.las'))
     del las.params['MDEN']
     assert las.params.keys() == ['BHT', 'BS', 'FD', 'MATR', 'RMF', 'DFD']

--- a/tests/test_delete_items.py
+++ b/tests/test_delete_items.py
@@ -14,13 +14,9 @@ stegfn = lambda vers, fn: os.path.join(
     os.path.dirname(__file__), "examples", vers, fn)
 
 def test_delete_curve():
-    l = lasio.read(egfn("sample.las"))
-    shape = l.data.shape[1]
-    curve = l.curves.keys()[1]
-    l.delete_curve(curve)
-    assert curve not in l.curves.keys()
-    assert len(l.curves.keys()) == (shape - 1)
-    assert l.curves.keys() == ['DEPT', 'RHOB', 'NPHI', 'SFLU', 'SFLA','ILM', 'ILD']
+    las = lasio.read(egfn("sample.las"))
+    del las.curves['DT']
+    assert las.curves.keys() == ['DEPT', 'RHOB', 'NPHI', 'SFLU', 'SFLA','ILM', 'ILD']
 
 def test_delete_section_item_by_index():
     las = lasio.read(egfn('sample.las'))


### PR DESCRIPTION
You can now delete any item from any SectionItems object with the ``del`` statement, e.g.

```python
>>> del las.params['MDEN']
```

will remove the HeaderItem with mnemonic MDEN from the ``las.params`` SectionItems object.

Of course the index also works.