### PR TITLE
Fix pprint/__repr__ bug

### DIFF
--- a/lasio/las_items.py
+++ b/lasio/las_items.py
@@ -99,11 +99,15 @@ class HeaderItem(OrderedDict):
         super(HeaderItem, self).__setattr__(key, value)
 
     def __repr__(self):
-        return (
+        result = (
             '%s(mnemonic=%s, unit=%s, value=%s, '
-            'descr=%s, original_mnemonic=%s)' % (
+            'descr=%s)' % (
                 self.__class__.__name__, self.mnemonic, self.unit, self.value,
-                self.descr, self.original_mnemonic))
+                self.descr))
+        if len(result) > 80:
+            return result[:76] + '...)'
+        else:
+            return result
 
     def _repr_pretty_(self, p, cycle):
         return p.text(self.__repr__())

--- a/tests/test_enhancements.py
+++ b/tests/test_enhancements.py
@@ -8,6 +8,7 @@ import pytest
 import math
 
 import lasio
+import lasio.las_items
 from lasio import las, read, exceptions
 
 
@@ -82,5 +83,5 @@ def test_non_standard_sections():
     assert "extra special information" in l.sections.keys()
 
 def test_repr():
-    h = lasio.HeaderItem('MN', unit='m', value=20, descr='test testing')
+    h = lasio.las_items.HeaderItem('MN', unit='m', value=20, descr='test testing')
     assert h.__repr__() == pformat(h)

--- a/tests/test_enhancements.py
+++ b/tests/test_enhancements.py
@@ -1,11 +1,13 @@
 import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import fnmatch
+from pprint import pformat
 
 import numpy
 import pytest
 import math
 
+import lasio
 from lasio import las, read, exceptions
 
 
@@ -78,3 +80,7 @@ def test_non_standard_sections():
     l = read(egfn("non-standard-header-sections.las"))
     assert "SPECIAL INFORMATION" in l.sections.keys()
     assert "extra special information" in l.sections.keys()
+
+def test_repr():
+    h = lasio.HeaderItem('MN', unit='m', value=20, descr='test testing')
+    assert h.__repr__() == pformat(h)


### PR DESCRIPTION
With pprint in Python 3, ``HeaderItem.__repr__()`` results that were longer than 80 characters were discarded, and pprint reverted to the parent object's `__repr__()`, which was OrderedDict's ``{}``.

This PR truncates the `HeaderItem.__repr__()` result so that it is always < 80 chars.