### PR TITLE
Allowing characters in the data section

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -349,9 +349,12 @@ def read_data_section_iterative(file_obj, regexp_subs, value_null_subs):
             for pattern, sub_str in regexp_subs:
                 line = re.sub(pattern, sub_str, line)
             for item in line.split():
-                yield item
+                try:
+                    yield np.float64(item)
+                except ValueError:
+                    yield item
 
-    array = np.fromiter(items(file_obj), np.float64, -1)
+    array = np.array([i for i in items(file_obj)])
     for value in value_null_subs:
         array[array == value] = np.nan
     return array

--- a/tests/examples/data_characters.las
+++ b/tests/examples/data_characters.las
@@ -1,0 +1,42 @@
+~Version Information
+VERS.             2.0 : CWLS log ASCII standard - Version 2.0
+WRAP.             NO  : One line per depth step
+#
+~Well Information Block
+#MNEM.UNIT                   Data Type:Information
+#__________________________________________________________
+  STRT.           01-JAN-2020 00:00:00 : START INDEX
+  STOP.           01-JAN-2020 00:00:01 : STOP INDEX
+  STEP.SEC           10.0000 : STEP
+  NULL.              -999.25 : NULL VALUE
+  COMP.                      : COMPANY
+  WELL.                      : WELL
+   FLD.                      : FIELD
+   LOC.                      : LOCATION
+  PROV.                      : PROVINCE
+  CNTY.                      : COUNTY
+  STAT.                      : STATE
+  CTRY.                      : COUNTRY
+  SRVC.                      : SERVICE COMPANY
+  DATE.                      : LOG DATE
+   UWI.                      : UNIQUE WELL ID
+   API.                      : API NUMBER
+#
+~Curve Information Block
+#MNEM.UNIT                     : Curve Description
+#---------                     --------------------
+TIME	    .HHMMSS	       :
+DATE	    .D		       :
+DEPT        .M                 : Bit Depth 2hz
+ARC_GR_UNC_RT.GAPI              : ARC Raw Gamma Ray, Real-Time
+#
+~Parameter Information Block
+#MNEM.UNIT                       Value:Description
+#__________________________________________________________
+#
+~Other Information Block
+
+#
+~A TIME       DATE       DEPT ARC_GR_UNC_RT
+00:00:00 01-Jan-20  1500.2435        126.56
+00:00:01 01-Jan-20  1500.3519        126.56

--- a/tests/test_null_policy.py
+++ b/tests/test_null_policy.py
@@ -61,8 +61,8 @@ def test_null_policy_custom_2():
     assert las['SFLA'][2] == -999.25
 
 def test_null_policy_ERR_strict():
-    with pytest.raises(exceptions.LASDataError):
-        las = read(egfn("null_policy_ERR.las"), null_policy='strict')
+    las = read(egfn("null_policy_ERR.las"), null_policy='strict')
+    assert las['RHOB'][2] == 'ERR'
     
 def test_null_policy_ERR_custom():
     las = read(egfn("null_policy_ERR.las"), null_policy=[('ERR', ' NaN '), ])

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -202,4 +202,9 @@ def test_emptyparam(capsys):
     las = lasio.read(egfn('emptyparam.las'))
     out, err = capsys.readouterr()
     msg = 'Header section Parameter regexp=~P is empty.'
-    assert not msg in out 
+    assert not msg in out
+
+def test_data_characters():
+    las = lasio.read(egfn('data_characters.las'))
+    assert las['TIME'][0] == '00:00:00'
+    assert las['DATE'][0] == '01-Jan-20'


### PR DESCRIPTION
A small example to approach allowing the characters to be present in the data section.

Leaving the values that could not be parsed as float64 as strings.