### PR TITLE
Update writer.py

### DIFF
--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -126,7 +126,7 @@ def write(las, file_object, version=None, wrap=None, STRT=None,
 
     # ~Curves
     logger.debug('LASFile.write Curves section')
-    lines.append('~Curves '.ljust(60, '-'))
+    lines.append('~Curve Information '.ljust(60, '-'))
     order_func = get_section_order_function('Curves', version)
     section_widths = get_section_widths(
         'Curves', las.curves, version, order_func)


### PR DESCRIPTION
When loading a .las into Petrel 2016, the .las importing utility will not recognize the curves with, "~Curves," but does recognize the curves with, "~Curve" or "~Curve Information"