### PR TITLE
Default output not working in Petrel

### DIFF
--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -126,7 +126,7 @@ def write(las, file_object, version=None, wrap=None, STRT=None,
 
     # ~Curves
     logger.debug('LASFile.write Curves section')
-    lines.append('~Curves '.ljust(60, '-'))
+    lines.append('~Curve Information '.ljust(60, '-'))
     order_func = get_section_order_function('Curves', version)
     section_widths = get_section_widths(
         'Curves', las.curves, version, order_func)

--- a/tests/examples/test_write_sect_widths_12.txt
+++ b/tests/examples/test_write_sect_widths_12.txt
@@ -14,7 +14,7 @@ PROV   . PROVINCE : SASKATCHEWAN
 SRVC   .  SERVICE : The company that did this logging has a very very long name....
 DATE   . LOG DATE : 25-DEC-1988
 UWI    .  WELL ID : 100091604920W300
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 D.M     : 1  DEPTH
 A.US/M  : 2  SONIC TRANSIT TIME
 B.K/M3  : 3  BULK DENSITY

--- a/tests/test_wrapped.py
+++ b/tests/test_wrapped.py
@@ -35,7 +35,7 @@ SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
 SON .                   142085 : SERVICE ORDER
 DATE.                13-DEC-86 : LOG DATE
 UWI .                          : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT.M     : Depth
 DT  .US/M  : 1 Sonic Travel Time
 RHOB.K/M   : 2 Density-Bulk Density
@@ -130,7 +130,7 @@ SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
 SON .                   142085 : SERVICE ORDER
 DATE.                13-DEC-86 : LOG DATE
 UWI .                          : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT.M     : Depth
 DT  .US/M  : 1 Sonic Travel Time
 RHOB.K/M   : 2 Density-Bulk Density

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -56,7 +56,7 @@ PROV.   ALBERTA : PROVINCE
 SRVC.   LOGGING : SERVICE COMPANY ARE YOU KIDDING THIS IS A REALLY REALLY LONG STRING
 DATE. 13-DEC-86 : LOG DATE
 UWI .  10012340 : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT.M                 : 1  DEPTH
 DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
 RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
@@ -105,7 +105,7 @@ PROV.                                                         ALBERTA : PROVINCE
 SRVC. The company that did this logging has a very very long name.... : SERVICE COMPANY
 DATE.                                                       13-DEC-86 : LOG DATE
 UWI .                                                100123401234W500 : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT.M                 : 1  DEPTH
 DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
 RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
@@ -160,7 +160,7 @@ PROV.             SASKATCHEWAN : PROVINCE
 SRVC. ANY LOGGING COMPANY LTD. : SERVICE COMPANY
 DATE.              25-DEC-1988 : LOG DATE
 UWI .         100091604920W300 : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT    .M     : 1  DEPTH
 DT      .US/M  : 2  SONIC TRANSIT TIME
 RHOB    .K/M3  : 3  BULK DENSITY
@@ -221,7 +221,7 @@ PROV.             SASKATCHEWAN : PROVINCE
 SRVC. ANY LOGGING COMPANY LTD. : SERVICE COMPANY
 DATE.              25-DEC-1988 : LOG DATE
 UWI .         100091604920W300 : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT.M     : 1  DEPTH
 RHO .ohmm  : curve 1,2,3
 RHO .ohmm  : curve 10,20,30
@@ -265,7 +265,7 @@ PROV.             SASKATCHEWAN : PROVINCE
 SRVC. ANY LOGGING COMPANY LTD. : SERVICE COMPANY
 DATE.              25-DEC-1988 : LOG DATE
 UWI .         100091604920W300 : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT.M     : 1  DEPTH
     .ohmm  : curve 1,2,3
     .ohmm  : curve 10,20,30
@@ -310,7 +310,7 @@ PROV.             SASKATCHEWAN : PROVINCE
 SRVC. ANY LOGGING COMPANY LTD. : SERVICE COMPANY
 DATE.              25-DEC-1988 : LOG DATE
 UWI .         100091604920W300 : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT.FT    : 1  DEPTH
 DT  .US/M  : 2  SONIC TRANSIT TIME
 RHOB.K/M3  : 3  BULK DENSITY
@@ -412,7 +412,7 @@ PROV.             SASKATCHEWAN : PROVINCE
 SRVC. ANY LOGGING COMPANY LTD. : SERVICE COMPANY
 DATE.              25-DEC-1988 : LOG DATE
 UWI .         100091604920W300 : UNIQUE WELL ID
-~Curves ----------------------------------------------------
+~Curve Information -----------------------------------------
 DEPT    .M     : 1  DEPTH
 New_DT  .US/M  : 2  SONIC TRANSIT TIME
 New_RHOB.K/M3  : 3  BULK DENSITY


### PR DESCRIPTION
Ref #239 @Fry484

Changes the default output of lasio from ``~Curves`` to ``~Curve Information`` because apparently the former does not work in Petrel.
