### PR TITLE
Make Reader Keyboard-Interruptable and more robust for faulty LAS files

### DIFF
--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -1,5 +1,8 @@
 import os
 
+import logging
+logger = logging.getLogger(__name__)
+
 from .las import LASFile, JSONEncoder
 from .las_items import CurveItem, HeaderItem, SectionItems
 from .reader import open_file
@@ -10,7 +13,6 @@ except ImportError:
     pass
 else:
     from .excel import ExcelConverter
-
 
 __version__ = '0.22'
 

--- a/lasio/excel.py
+++ b/lasio/excel.py
@@ -39,7 +39,7 @@ class ExcelConverter(object):
         Two sheets are created:
 
         * Header: contains all the header sections and metadata
-        * Curves: contains the data 
+        * Curves: contains the data
 
         '''
         wb = openpyxl.Workbook()
@@ -109,7 +109,7 @@ def main():
 
 
 def get_parser():
-    parser = argparse.ArgumentParser('Convert LAS file to XLSX', 
+    parser = argparse.ArgumentParser('Convert LAS file to XLSX',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('LAS_filename')
     parser.add_argument('XLSX_filename')
@@ -139,7 +139,7 @@ def main_bulk():
 
 
 def get_bulk_parser():
-    parser = argparse.ArgumentParser('Convert LAS files to XLSX', 
+    parser = argparse.ArgumentParser('Convert LAS files to XLSX',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-g', '--glob', default='*.las', help='Match LAS files with this pattern')
     parser.add_argument('-r', '--recursive', action='store_true', help='Recurse through subfolders.', default=False)

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -132,6 +132,15 @@ class LASFile(object):
             if raw_section:
                 self.sections[name] = reader.parse_header_section(raw_section,
                                                                   **sect_kws)
+                for item in self.sections[name]:
+                    if item.mnemonic.find("UNMATCHED_")==0:
+                        self._warn(
+                            "Section %s has unmatched line '%s'" % (
+                                name,
+                                item.value),
+                            { "name" : name , "pattern" : pattern ,
+                              "line" : item.value }
+                        )
                 drop.append(raw_section["title"])
             else:
                 self._warn(

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import codecs
 import csv
 import json
-import logging
 import os
 import re
 import textwrap
@@ -36,8 +35,7 @@ from . import defaults
 from . import reader
 from . import writer
 
-logger = logging.getLogger(__name__)
-
+from . import logger
 
 class LASFile(object):
 

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -385,16 +385,26 @@ class LASFile(object):
         Intended for internal use only.
 
         '''
+        p = re.compile(pattern, flags=flags)
+        if re_func == "match":
+            re_func = re.match
+        elif re_func == "search":
+            re_func = re.search
+
+        sec=None
+
         for title in self.raw_sections.keys():
             title = title.strip()
-            p = re.compile(pattern, flags=flags)
-            if re_func == "match":
-                re_func = re.match
-            elif re_func == "search":
-                re_func == re.search
             m = re_func(p, title)
             if m:
-                return self.raw_sections[title]
+                if sec is None:
+                    sec=self.raw_sections[title]
+                else:
+                    self._warn(
+                        "Redundant match for section %s: Section '%s'" % (pattern,title),
+                        { "pattern" : pattern , "keys" : list(self.raw_sections.keys()) }
+                    )
+        return sec
 
     def get_curve(self, mnemonic):
         '''Return CurveItem object.

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -44,7 +44,7 @@ class LASFile(object):
     '''LAS file object.
 
     Keyword Arguments:
-        file_ref (file-like object, str): either a filename, an open file 
+        file_ref (file-like object, str): either a filename, an open file
             object, or a string containing the contents of a file.
 
     See these routines for additional keyword arguments you can use when
@@ -77,22 +77,22 @@ class LASFile(object):
         if not (file_ref is None):
             self.read(file_ref, **read_kwargs)
 
-    def read(self, file_ref, 
+    def read(self, file_ref,
              ignore_data=False, read_policy='default', null_policy='strict',
-             ignore_header_errors=False, mnemonic_case='upper', 
+             ignore_header_errors=False, mnemonic_case='upper',
              **kwargs):
         '''Read a LAS file.
 
         Arguments:
-            file_ref (file-like object, str): either a filename, an open file 
+            file_ref (file-like object, str): either a filename, an open file
                 object, or a string containing the contents of a file.
 
         Keyword Arguments:
-            null_policy (str or list): see 
+            null_policy (str or list): see
                 http://lasio.readthedocs.io/en/latest/data-section.html#handling-invalid-data-indicators-automatically
-            ignore_data (bool): if True, do not read in any of the actual data, 
+            ignore_data (bool): if True, do not read in any of the actual data,
                 just the header metadata. False by default.
-            ignore_header_errors (bool): ignore LASHeaderErrors (False by 
+            ignore_header_errors (bool): ignore LASHeaderErrors (False by
                 default)
             mnemonic_case (str): 'preserve': keep the case of HeaderItem mnemonics
                                  'upper': convert all HeaderItem mnemonics to uppercase
@@ -122,7 +122,7 @@ class LASFile(object):
             raw_section = self.match_raw_section(pattern)
             drop = []
             if raw_section:
-                self.sections[name] = reader.parse_header_section(raw_section, 
+                self.sections[name] = reader.parse_header_section(raw_section,
                                                                   **sect_kws)
                 drop.append(raw_section["title"])
             else:
@@ -131,7 +131,7 @@ class LASFile(object):
             for key in drop:
                 self.raw_sections.pop(key)
 
-        add_section("~V", "Version", version=1.2, 
+        add_section("~V", "Version", version=1.2,
                     ignore_header_errors=ignore_header_errors,
                     mnemonic_case=mnemonic_case)
 
@@ -169,7 +169,7 @@ class LASFile(object):
                 logger.info('Assuming that LAS VERS is 2.0')
                 version = 2
 
-        add_section("~W", "Well", version=version, 
+        add_section("~W", "Well", version=version,
                     ignore_header_errors=ignore_header_errors,
                     mnemonic_case=mnemonic_case)
 
@@ -181,10 +181,10 @@ class LASFile(object):
             logger.warning('NULL item not found in the ~W section')
             null = None
 
-        add_section("~C", "Curves", version=version, 
+        add_section("~C", "Curves", version=version,
                     ignore_header_errors=ignore_header_errors,
                     mnemonic_case=mnemonic_case)
-        add_section("~P", "Parameter", version=version, 
+        add_section("~P", "Parameter", version=version,
                     ignore_header_errors=ignore_header_errors,
                     mnemonic_case=mnemonic_case)
         s = self.match_raw_section("~O")
@@ -257,7 +257,7 @@ class LASFile(object):
         Arguments:
             file_ref (open file-like object or str): a file-like object opening
                 for writing, or a filename.
-    
+
         All ``**kwargs`` are passed to :func:`lasio.writer.write` -- please
         check the docstring of that function for more keyword arguments you can
         use here!
@@ -303,8 +303,8 @@ class LASFile(object):
                 use the curve mnemonics.
             units (list, True, False): as for mnemonics.
             units_loc (str or None): either 'line', '[]' or '()'. 'line' will put
-                units on the line following the mnemonics (good for WellCAD). 
-                '[]' and '()' will put the units in either brackets or 
+                units on the line following the mnemonics (good for WellCAD).
+                '[]' and '()' will put the units in either brackets or
                 parentheses following the mnemonics, on the single header line
                 (better for Excel)
             **kwargs: passed to :class:`csv.writer`. Note that if
@@ -320,7 +320,7 @@ class LASFile(object):
         if not 'lineterminator' in kwargs:
             kwargs['lineterminator'] = '\n'
         writer = csv.writer(file_ref, **kwargs)
-        
+
         if mnemonics is True:
             mnemonics = [c.original_mnemonic for c in self.curves]
         if units is True:
@@ -329,7 +329,7 @@ class LASFile(object):
         if mnemonics:
             if units_loc in ('()', '[]') and units:
                 mnemonics = [
-                    m + ' ' + units_loc[0] + u + units_loc[1] 
+                    m + ' ' + units_loc[0] + u + units_loc[1]
                     for m, u in zip(mnemonics, units)]
             writer.writerow(mnemonics)
         if units:
@@ -338,7 +338,7 @@ class LASFile(object):
 
         for i in range(self.data.shape[0]):
             writer.writerow(self.data[i, :])
-        
+
         if opened_file:
             file_ref.close()
 
@@ -409,7 +409,7 @@ class LASFile(object):
             key (str): the curve mnemonic
             value (1D data or CurveItem): either the curve data, or a CurveItem
 
-        See :meth:`lasio.las.LASFile.append_curve_item` or 
+        See :meth:`lasio.las.LASFile.append_curve_item` or
         :meth:`lasio.las.LASFile.append_curve` for more details.
 
         '''
@@ -621,7 +621,7 @@ class LASFile(object):
         for i, curve in enumerate(self.curves):
             curve.mnemonic = names[i]
             curve.data = data[:, i]
-            
+
         self.curves.assign_duplicate_suffixes()
 
     def set_data_from_df(self, df, **kwargs):

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -255,7 +255,14 @@ class LASFile(object):
                 if wrap == "NO":
                     if s["ncols"] > n_curves:
                         n_arr_cols = s["ncols"]
-                data = np.reshape(arr, (-1, n_arr_cols))
+                try:
+                    data = np.reshape(arr, (-1, n_arr_cols))
+                except ValueError as e:
+                    self._warn(
+                        "Can't convert ~A section to data: "+str(e),
+                        { "arr" : arr , "cols" : n_arr_cols }
+                    )
+                    data=np.asarray([])
                 self.set_data(data, truncate=False)
                 drop.append(s["title"])
             for key in drop:
@@ -482,7 +489,7 @@ class LASFile(object):
         '''Header information from the Well (~W) section.
 
         Returns:
-            :class:`lasio.las_items.SectionItems` object.
+            :class:`lasio.las_items.SectionIrtems` oobject.
 
         '''
         return self.sections['Well']
@@ -626,6 +633,13 @@ class LASFile(object):
                 return self.set_data_from_df(
                     array_like, **dict(names=names, truncate=False))
         data = np.asarray(array_like)
+
+        if len(data.shape)!=2:
+            self._warn(
+                "Data is not 2-dimensional. Shape: %s" % str(data.shape),
+                { "data" : data }
+            )
+            return
 
         # Truncate data array if necessary.
         if truncate:

--- a/lasio/las_items.py
+++ b/lasio/las_items.py
@@ -71,7 +71,7 @@ class HeaderItem(OrderedDict):
     def set_session_mnemonic_only(self, value):
         '''Set the mnemonic for session use.
 
-        See source comments for :class:`lasio.las_items.HeaderItem.__init__` 
+        See source comments for :class:`lasio.las_items.HeaderItem.__init__`
         for a more in-depth explanation.
 
         '''
@@ -96,13 +96,13 @@ class HeaderItem(OrderedDict):
                 'CurveItem only has restricted items (not %s)' % key)
 
     def __setattr__(self, key, value):
-        
+
         if key == 'mnemonic':
-            
+
             # The user wants to rename the item! This means we must send their
             # new mnemonic to the original_mnemonic attribute. Remember that the
             # mnemonic attribute is for session use only.
-            
+
             self.original_mnemonic = value
             self.set_session_mnemonic_only(self.useful_mnemonic)
         else:
@@ -123,7 +123,7 @@ class HeaderItem(OrderedDict):
         return p.text(self.__repr__())
 
     def __reduce__(self):
-        return self.__class__, (self.mnemonic, self.unit, self.value, 
+        return self.__class__, (self.mnemonic, self.unit, self.value,
                                 self.descr, self.data)
 
     @property
@@ -199,7 +199,7 @@ class SectionItems(list):
         rstr_lines = []
         data = [['Mnemonic', 'Unit', 'Value', 'Description'],
                 ['--------', '----', '-----', '-----------']]
-        data += [[str(x) for x in [item.mnemonic, item.unit, item.value, 
+        data += [[str(x) for x in [item.mnemonic, item.unit, item.value,
                                    item.descr]] for item in self]
         col_widths = []
         for i in range(len(data[0])):
@@ -325,7 +325,7 @@ class SectionItems(list):
             >>> section.OPERATOR
             HeaderItem(mnemonic='OPERATOR', value='Kent')
 
-        See :meth:`lasio.las_items.SectionItems.set_item` and 
+        See :meth:`lasio.las_items.SectionItems.set_item` and
         :meth:`lasio.las_items.SectionItems.set_item_value`.
 
         '''
@@ -365,7 +365,7 @@ class SectionItems(list):
         '''Replace an item by comparison of session mnemonics.
 
         Arguments:
-            key (str): the item mnemonic (or HeaderItem with mnemonic) 
+            key (str): the item mnemonic (or HeaderItem with mnemonic)
                 you want to replace.
             newitem (HeaderItem): the new item
 
@@ -376,7 +376,7 @@ class SectionItems(list):
             if self.mnemonic_compare(key, item.mnemonic):
 
                 # This is very important. We replace items where
-                # 'mnemonic' is equal - i.e. we do not check 
+                # 'mnemonic' is equal - i.e. we do not check
                 # against useful_mnemonic or original_mnemonic.
 
                 return super(SectionItems, self).__setitem__(i, newitem)

--- a/lasio/las_items.py
+++ b/lasio/las_items.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 # The standard library OrderedDict was introduced in Python 2.7 so
 # we have a third-party option to support Python 2.6
@@ -11,8 +10,7 @@ except ImportError:
 
 import numpy as np
 
-logger = logging.getLogger(__name__)
-
+from . import logger
 
 class HeaderItem(OrderedDict):
 

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -274,6 +274,8 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs,
             if not ignore_data:
                 try:
                     data = read_data_section_iterative(file_obj, regexp_subs, value_null_subs)
+                except KeyboardInterrupt:
+                    raise
                 except:
                     raise exceptions.LASDataError(
                         traceback.format_exc()[:-1] + 

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -666,6 +666,12 @@ def read_header_line(line, pattern=None):
                        r'(?P<value>[^:]*):' +
                        r'(?P<descr>.*)')
     m = re.match(pattern, line)
+    if m is None:
+        logger.warning("Header line '%s' does not match patterm %s" % (line,pattern))
+        d["value"]=line
+        d["name"]="Unmatched_%03d" % read_header_line.unmatchedNr
+        read_header_line.unmatchedNr += 1
+        return d
     mdict = m.groupdict()
     for key, value in mdict.items():
         d[key] = value.strip()
@@ -673,3 +679,6 @@ def read_header_line(line, pattern=None):
             if d[key].endswith('.'):
                 d[key] = d[key].strip('.')  # see issue #36
     return d
+
+# Counter for the unmatched lines in the header (to make them unique)
+read_header_line.unmatchedNr = 1

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -57,7 +57,7 @@ def open_file(file_ref, **encoding_kwargs):
     See :func:`lasio.reader.open_with_codecs` for keyword arguments that can be
     used here.
 
-    Returns: 
+    Returns:
         tuple of an open file-like object, and the encoding that
         was used to decode it (if it were read from disk).
 
@@ -100,13 +100,13 @@ def open_with_codecs(filename, encoding=None, encoding_errors='replace',
             :func:`codecs.open`.
         encoding_errors (str): 'strict', 'replace' (default), 'ignore' - how to
             handle errors with encodings (see
-            `this section 
+            `this section
             <https://docs.python.org/3/library/codecs.html#codec-base-classes>`__
             of the standard library's :mod:`codecs` module for more information)
-        autodetect_encoding (str or bool): default True to use 
-            `chardet <https://github.com/chardet/chardet>`__/`cchardet 
-            <https://github.com/PyYoshi/cChardet>`__ to detect encoding. 
-            Note if set to False several common encodings will be tried but 
+        autodetect_encoding (str or bool): default True to use
+            `chardet <https://github.com/chardet/chardet>`__/`cchardet
+            <https://github.com/PyYoshi/cChardet>`__ to detect encoding.
+            Note if set to False several common encodings will be tried but
             chardet won't be used.
         autodetect_encoding_chars (int/None): number of chars to read from LAS
             file for auto-detection of encoding.
@@ -139,7 +139,7 @@ def open_with_codecs(filename, encoding=None, encoding_errors='replace',
                 raw = test.read(nbytes)
         encoding = get_encoding(autodetect_encoding, raw)
         autodetect_encoding = False
-        
+
     # Or if no BOM found & chardet not installed
     if (not autodetect_encoding) and (not encoding):
         encoding = adhoc_test_encoding(filename)
@@ -215,7 +215,7 @@ def get_encoding(auto, raw):
     return result['encoding']
 
 
-def read_file_contents(file_obj, regexp_subs, value_null_subs, 
+def read_file_contents(file_obj, regexp_subs, value_null_subs,
                        ignore_data=False):
     '''Read file contents into memory.
 
@@ -278,7 +278,7 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs,
                     raise
                 except:
                     raise exceptions.LASDataError(
-                        traceback.format_exc()[:-1] + 
+                        traceback.format_exc()[:-1] +
                         ' in data section beginning line {}'.format(i + 1))
                 sections[line] = {
                     "section_type": "data",
@@ -367,16 +367,16 @@ def get_substitutions(read_policy, null_policy):
     substitutions.
 
     Arguments:
-        read_policy (str, list, or substitution): either (1) a string defined in 
+        read_policy (str, list, or substitution): either (1) a string defined in
             defaults.READ_POLICIES; (2) a list of substitutions as defined by
             the keys of defaults.READ_SUBS; or (3) a list of actual substitutions
             similar to the values of defaults.READ_SUBS. You can mix (2) and (3)
             together if you want.
-        null_policy (str, list, or sub): as for read_policy but for 
+        null_policy (str, list, or sub): as for read_policy but for
             defaults.NULL_POLICIES and defaults.NULL_SUBS
 
     Returns:
-        regexp_subs, value_null_subs, version_NULL - two lists and a bool. 
+        regexp_subs, value_null_subs, version_NULL - two lists and a bool.
         The first list is pairs of regexp patterns and substrs, and the second
         list is just a list of floats or integers. The bool is whether or not
         'NULL' was located as a substitution.
@@ -419,11 +419,11 @@ def get_substitutions(read_policy, null_policy):
             except TypeError:
                 logger.debug('added numerical substitution: {}'.format(item))
                 numerical_subs.append(item)
-            else:                
+            else:
                 logger.debug('added regexp substitution: pattern={} substr="{}"'.format(item[0], item[1]))
                 regexp_subs.append(item)
     numerical_subs = [n for n in numerical_subs if not n is None]
-                
+
     return regexp_subs, numerical_subs, version_NULL
 
 
@@ -456,7 +456,7 @@ def parse_header_section(sectdict, version, ignore_header_errors=False,
     assert mnemonic_case in ('upper', 'lower', 'preserve')
     if not mnemonic_case == 'preserve':
         section.mnemonic_transforms = True
-    
+
     for i in range(len(sectdict["lines"])):
         line = sectdict["lines"][i]
         j = sectdict["line_nos"][i]
@@ -550,7 +550,7 @@ class SectionParser(object):
         '''
         if default is None:
             default = x
-        
+
         # in case it is a string.
         try:
             pattern, sub = defaults.READ_SUBS['comma-decimal-mark'][0]

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -290,6 +290,13 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs,
         elif line.startswith('~'):
             if section_exists:
                 # We have ended a section and need to start the next
+                if sect_title_line in sections:
+                    logger.warning("Section '%s' exists at least twice in file" % sect_title_line)
+                    while sect_title_line in sections:
+                        # This is trouble if there are too many duplicate sections.
+                        # But then the whole LAS-file probably has a problem
+                        sect_title_line+="_Duplicate"
+
                 sections[sect_title_line] = {
                     "section_type": "header",
                     "title": sect_title_line,

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -1,5 +1,4 @@
 import codecs
-import logging
 import os
 import re
 import textwrap
@@ -8,6 +7,8 @@ import traceback
 import numpy as np
 
 from . import defaults
+
+from . import logger
 
 # Convoluted import for StringIO in order to support:
 #
@@ -30,9 +31,6 @@ else:
 from . import defaults
 from . import exceptions
 from .las_items import HeaderItem, CurveItem, SectionItems, OrderedDict
-
-
-logger = logging.getLogger(__name__)
 
 URL_REGEXP = re.compile(
     r'^(?:http|ftp)s?://'  # http:// or https://

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -18,7 +18,7 @@ def write(las, file_object, version=None, wrap=None, STRT=None,
         file_object (file-like object open for writing): output
 
     Keyword Arguments:
-        version (float or None): version of written file, either 1.2 or 2. 
+        version (float or None): version of written file, either 1.2 or 2.
             If this is None, ``las.version.VERS.value`` will be used.
         wrap (bool or None): whether to wrap the output data section.
             If this is None, ``las.version.WRAP.value`` will be used.
@@ -34,7 +34,7 @@ def write(las, file_object, version=None, wrap=None, STRT=None,
         fmt (str): Python string formatting operator for numeric data to be
             used.
 
-    You should avoid calling this function directly - instead use the 
+    You should avoid calling this function directly - instead use the
     :meth:`lasio.las.LASFile.write` method.
 
     '''
@@ -183,7 +183,7 @@ def write(las, file_object, version=None, wrap=None, STRT=None,
                          (len(lines), depth_slice))
         else:
             lines = [depth_slice]
-                    
+
         for line in lines:
             if las.version['VERS'].value == 1.2 and len(line) > 255:
                 logger.warning('[v1.2] line #{} has {} chars (>256)'.format(
@@ -205,8 +205,8 @@ def get_formatter_function(order, left_width=None, middle_width=None):
             first period from the left and the first colon from the left.
 
     Returns:
-        A function which takes a header item 
-        (e.g. :class:`lasio.las_items.HeaderItem`) as its single argument and 
+        A function which takes a header item
+        (e.g. :class:`lasio.las_items.HeaderItem`) as its single argument and
         which in turn returns a string which is the correctly formatted LAS
         header line.
 
@@ -247,7 +247,7 @@ def get_section_order_function(section, version,
         order_definitions (dict): see source of defaults.py for more information
 
     Returns:
-        A function which takes a mnemonic (str) as its only argument, and 
+        A function which takes a mnemonic (str) as its only argument, and
         in turn returns the order 'value:descr' or 'descr:value'.
 
     '''

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -1,4 +1,3 @@
-import logging
 import textwrap
 
 import numpy as np
@@ -8,8 +7,7 @@ from .las_items import (
 from . import defaults
 from . import exceptions
 
-logger = logging.getLogger(__name__)
-
+from . import logger
 
 def write(las, file_object, version=None, wrap=None, STRT=None,
           STOP=None, STEP=None, fmt='%.5f'):

--- a/tests/examples/2.0/sample_2.0_duplicateHeader.las
+++ b/tests/examples/2.0/sample_2.0_duplicateHeader.las
@@ -1,0 +1,50 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/examples/2.0/sample_2.0_misformed.las
+++ b/tests/examples/2.0/sample_2.0_misformed.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  ****************
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/examples/2.0/sample_2.0_wrongHeader.las
+++ b/tests/examples/2.0/sample_2.0_wrongHeader.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV                                             :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -50,8 +50,7 @@ def test_read_v2_sample_wrapped():
 
 
 def test_dodgy_param_sect():
-    with pytest.raises(lasio.exceptions.LASHeaderError):
-        l = lasio.read(egfn("dodgy_param_sect.las"))
+    l = lasio.read(egfn("dodgy_param_sect.las"))
 
 def test_ignore_header_errors():
     l = lasio.read(egfn("dodgy_param_sect.las"), ignore_header_errors=True)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 def test_read_v12_sample():
     l = lasio.read(stegfn("1.2", "sample.las"))
-    
+
 
 def test_read_v12_sample_curve_api():
     l = lasio.read(stegfn("1.2", "sample_curve_api.las"))
@@ -125,7 +125,7 @@ def test_missing_vers_write_version_none_fails():
 def test_missing_vers_write_version_specified_works():
     l = lasio.read(egfn("missing_vers.las"))
     l.write(sys.stdout, version=1.2)
-        
+
 def test_missing_wrap_loads():
     l = lasio.read(egfn("missing_wrap.las"))
 
@@ -141,7 +141,7 @@ def test_missing_wrap_write_wrap_none_fails():
 def test_missing_wrap_write_wrap_specified_works():
     l = lasio.read(egfn("missing_wrap.las"))
     l.write(sys.stdout, wrap=True)
-        
+
 def test_missing_null_loads():
     l = lasio.read(egfn("missing_null.las"))
 
@@ -179,10 +179,10 @@ def test_blank_line_in_header():
 
 def test_duplicate_step():
     las = lasio.read(egfn('duplicate_step.las'))
-    
+
 def test_blank_line_at_start():
     las = lasio.read(egfn('blank_line_start.las'))
-    
+
 def test_missing_STRT_STOP():
     las = lasio.read(egfn('sample_TVD.las'))
     assert len(las.well) == 12
@@ -197,7 +197,7 @@ def test_sparse_curves():
 
 def test_issue92():
     las = lasio.read(egfn('issue92.las'), ignore_header_errors=True)
-    
+
 def test_emptyparam(capsys):
     las = lasio.read(egfn('emptyparam.las'))
     out, err = capsys.readouterr()
@@ -209,7 +209,7 @@ def test_data_characters_1():
     assert las['TIME'][0] == '00:00:00'
 
 def test_data_characters_2():
-    las = lasio.read(egfn('data_characters.las'))    
+    las = lasio.read(egfn('data_characters.las'))
     assert las['DATE'][0] == '01-Jan-20'
 
 def test_data_characters_types():

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -219,3 +219,12 @@ def test_data_characters_types():
     assert is_object_dtype(las.df()['DATE'].dtype)
     assert is_float_dtype(las.df()['DEPT'].dtype)
     assert is_float_dtype(las.df()['ARC_GR_UNC_RT'].dtype)
+
+def test_read_v2_sample_duplicate_header():
+    l = lasio.read(stegfn("2.0", "sample_2.0_duplicateHeader.las"))
+
+def test_read_v2_sample_missformed_data():
+    l = lasio.read(stegfn("2.0", "sample_2.0_misformed.las"))
+
+def test_read_v2_sample_wrong_header():
+    l = lasio.read(stegfn("2.0", "sample_2.0_wrongHeader.las"))

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -19,80 +19,98 @@ logger = logging.getLogger(__name__)
 
 def test_read_v12_sample():
     l = lasio.read(stegfn("1.2", "sample.las"))
+    assert len(l.problems)==0
 
 
 def test_read_v12_sample_curve_api():
     l = lasio.read(stegfn("1.2", "sample_curve_api.las"))
+    assert len(l.problems)==0
 
 
 def test_read_v12_sample_minimal():
     l = lasio.read(stegfn("1.2", "sample_minimal.las"))
+    assert len(l.problems)==1
 
 
 def test_read_v12_sample_wrapped():
     l = lasio.read(stegfn("1.2", "sample_wrapped.las"))
+    assert len(l.problems)==1
 
 
 def test_read_v2_sample():
     l = lasio.read(stegfn("2.0", "sample_2.0.las"))
+    assert len(l.problems)==0
 
 
 def test_read_v2_sample_based():
     l = lasio.read(stegfn("2.0", "sample_2.0_based.las"))
+    assert len(l.problems)==0
 
 
 def test_read_v2_sample_minimal():
     l = lasio.read(stegfn("2.0", "sample_2.0_minimal.las"))
+    assert len(l.problems)==1
 
 
 def test_read_v2_sample_wrapped():
     l = lasio.read(stegfn("2.0", "sample_2.0_wrapped.las"))
+    assert len(l.problems)==1
 
 
 def test_dodgy_param_sect():
     l = lasio.read(egfn("dodgy_param_sect.las"))
+    assert len(l.problems)==1
 
 def test_ignore_header_errors():
     l = lasio.read(egfn("dodgy_param_sect.las"), ignore_header_errors=True)
+    assert len(l.problems)==1
 
 def test_mnemonic_good():
     l = lasio.read(egfn("mnemonic_good.las"))
+    assert len(l.problems)==0
     assert [c.mnemonic for c in l.curves] == [
         "DEPT", "DT", "RHOB", "NPHI", "SFLU", "SFLA", "ILM", "ILD"]
 
 def test_mnemonic_duplicate():
     l = lasio.read(egfn("mnemonic_duplicate.las"))
+    assert len(l.problems)==0
     assert [c.mnemonic for c in l.curves] == [
         "DEPT", "DT", "RHOB", "NPHI", "SFLU:1", "SFLU:2", "ILM", "ILD"]
 
 
 def test_mnemonic_leading_period():
     l = lasio.read(egfn("mnemonic_leading_period.las"))
+    assert len(l.problems)==0
     assert [c.mnemonic for c in l.curves] == [
         "DEPT", "DT", "RHOB", "NPHI", "SFLU", "SFLA", "ILM", "ILD"]
 
 def test_mnemonic_missing():
     l = lasio.read(egfn("mnemonic_missing.las"))
+    assert len(l.problems)==0
     assert [c.mnemonic for c in l.curves] == [
         "DEPT", "DT", "RHOB", "NPHI", "UNKNOWN", "SFLA", "ILM", "ILD"]
 
 def test_mnemonic_missing_multiple():
     l = lasio.read(egfn("mnemonic_missing_multiple.las"))
+    assert len(l.problems)==0
     assert [c.mnemonic for c in l.curves] == [
         "DEPT", "DT", "RHOB", "NPHI", "UNKNOWN:1", "UNKNOWN:2", "ILM", "ILD"]
 
 def test_multi_curve_mnemonics():
     l = lasio.read(egfn('sample_issue105_a.las'))
+    assert len(l.problems)==0
     assert l.keys() == [c.mnemonic for c in l.curves] == ['DEPT', 'RHO:1', 'RHO:2', 'RHO:3', 'PHI']
 
 
 def test_multi_missing_curve_mnemonics():
     l = lasio.read(egfn('sample_issue105_b.las'))
+    assert len(l.problems)==0
     assert l.keys() == [c.mnemonic for c in l.curves] == ['DEPT', 'UNKNOWN:1', 'UNKNOWN:2', 'UNKNOWN:3', 'PHI']
 
 
 def test_multi_curve_mnemonics_gr():
     l = lasio.read(egfn('sample_issue105_c.las'))
+    assert len(l.problems)==0
     assert l.keys() == [c.mnemonic for c in l.curves] == ['DEPT', 'GR:1', 'GR:2', 'GR[0]', 'GR[1]', 'GR[2]', 'GR[3]', 'GR[4]', 'GR[5]']
 
 #  DEPT.M                      :  1  DEPTH
@@ -107,53 +125,66 @@ def test_multi_curve_mnemonics_gr():
 
 def test_inf_uwi():
     l = lasio.read(stegfn('2.0', 'sample_2.0_inf_uwi.las'))
+    assert len(l.problems)==0
     assert l.well['UWI'].value == '300E074350061450'
 
 def test_missing_vers_loads():
     l = lasio.read(egfn("missing_vers.las"))
+    assert len(l.problems)==1
 
 def test_missing_vers_missing_headeritem():
     l = lasio.read(egfn("missing_vers.las"))
+    assert len(l.problems)==1
     assert not 'VERS' in l.version
 
 def test_missing_vers_write_version_none_fails():
     l = lasio.read(egfn("missing_vers.las"))
+    assert len(l.problems)==1
     with pytest.raises(KeyError):
         l.write(sys.stdout, version=None)
 
 def test_missing_vers_write_version_specified_works():
     l = lasio.read(egfn("missing_vers.las"))
+    assert len(l.problems)==1
     l.write(sys.stdout, version=1.2)
 
 def test_missing_wrap_loads():
     l = lasio.read(egfn("missing_wrap.las"))
+    assert len(l.problems)==1
 
 def test_missing_wrap_missing_headeritem():
     l = lasio.read(egfn("missing_wrap.las"))
+    assert len(l.problems)==1
     assert not 'WRAP' in l.version
 
 def test_missing_wrap_write_wrap_none_fails():
     l = lasio.read(egfn("missing_wrap.las"))
+    assert len(l.problems)==1
     with pytest.raises(KeyError):
         l.write(sys.stdout, wrap=None)
 
 def test_missing_wrap_write_wrap_specified_works():
     l = lasio.read(egfn("missing_wrap.las"))
+    assert len(l.problems)==1
     l.write(sys.stdout, wrap=True)
 
 def test_missing_null_loads():
     l = lasio.read(egfn("missing_null.las"))
+    assert len(l.problems)==1
 
 def test_missing_null_missing_headeritem():
     l = lasio.read(egfn("missing_null.las"))
+    assert len(l.problems)==1
     assert not 'NULL' in l.well
 
 def test_barebones():
     las = lasio.read(egfn('barebones.las'))
+    assert len(las.problems)==3
     assert las['DEPT'][1] == 201
 
 def test_barebones_missing_all_sections():
     las = lasio.read(egfn('barebones2.las'))
+    assert len(las.problems)==4
     assert las.curves[-1].mnemonic == 'UNKNOWN:8'
 
 def test_not_a_las_file():
@@ -162,59 +193,73 @@ def test_not_a_las_file():
 
 def test_comma_decimal_mark_data():
     las = lasio.read(egfn('comma_decimal_mark.las'))
+    assert len(las.problems)==0
     assert las['SFLU'][1] == 123.42
 
 def test_comma_decimal_mark_params():
     las = lasio.read(egfn('comma_decimal_mark.las'))
+    assert len(las.problems)==0
     assert las.params['MDEN'].value == 2710.1
 
 def test_missing_a_section():
     las = lasio.read(egfn('missing_a_section.las'))
+    assert len(las.problems)==3
     assert not las.data
 
 def test_blank_line_in_header():
     las = lasio.read(egfn('blank_line.las'))
+    assert len(las.problems)==3
     assert las.curves[0].mnemonic == 'DEPT'
 
 def test_duplicate_step():
     las = lasio.read(egfn('duplicate_step.las'))
+    assert len(las.problems)==0
 
 def test_blank_line_at_start():
     las = lasio.read(egfn('blank_line_start.las'))
+    assert len(las.problems)==0
 
 def test_missing_STRT_STOP():
     las = lasio.read(egfn('sample_TVD.las'))
+    assert len(las.problems)==0
     assert len(las.well) == 12
 
 def test_UWI_API_leading_zero():
     las = lasio.read(egfn('UWI_API_leading_zero.las'))
+    assert len(las.problems)==0
     assert las.well['UWI'].value == '05123370660000'
 
 def test_sparse_curves():
     las = lasio.read(egfn('sparse_curves.las'))
+    assert len(las.problems)==0
     assert las.curves.keys() == ['DEPT', 'DT', 'RHOB', 'NPHI', 'SFLU', 'SFLA', 'ILM', 'ILD']
 
 def test_issue92():
     las = lasio.read(egfn('issue92.las'), ignore_header_errors=True)
+    assert len(las.problems)==5
 
 def test_emptyparam(capsys):
     las = lasio.read(egfn('emptyparam.las'))
+    assert len(las.problems)==0
     out, err = capsys.readouterr()
     msg = 'Header section Parameter regexp=~P is empty.'
     assert not msg in out
 
 def test_data_characters_1():
     las = lasio.read(egfn('data_characters.las'))
+    assert len(las.problems)==0
     assert las['TIME'][0] == '00:00:00'
 
 def test_data_characters_2():
     las = lasio.read(egfn('data_characters.las'))
+    assert len(las.problems)==0
     assert las['DATE'][0] == '01-Jan-20'
 
 def test_data_characters_types():
     from pandas.api.types import is_object_dtype
     from pandas.api.types import is_float_dtype
     las = lasio.read(egfn('data_characters.las'))
+    assert len(las.problems)==0
     assert is_object_dtype(las.df().index.dtype)
     assert is_object_dtype(las.df()['DATE'].dtype)
     assert is_float_dtype(las.df()['DEPT'].dtype)
@@ -222,9 +267,12 @@ def test_data_characters_types():
 
 def test_read_v2_sample_duplicate_header():
     l = lasio.read(stegfn("2.0", "sample_2.0_duplicateHeader.las"))
+    assert len(l.problems)==2
 
 def test_read_v2_sample_missformed_data():
     l = lasio.read(stegfn("2.0", "sample_2.0_misformed.las"))
+    assert len(l.problems)==2
 
 def test_read_v2_sample_wrong_header():
     l = lasio.read(stegfn("2.0", "sample_2.0_wrongHeader.las"))
+    assert len(l.problems)==1


### PR DESCRIPTION
I use the library to batch-process some LAS-files. When trying to interrupt the script with Ctrl-C it is not stopped because the `KeyboardInterrupt` is caught by a general `except:`and reraised as a `LASDataException` which definitely is not the right behaviour.

The first commit catches the Keyboard-Interrupt and reraises it

The second commit is only trailing whitespaces that my editor removes automatically. It can be ignored

General remark: the catch-all `except:` is not good practice and should always be replaced with the concrete exceptions that are to be expected