### PR TITLE
Add test case for issue286 - write on single depth

### DIFF
--- a/tests/examples/single_step_20.las
+++ b/tests/examples/single_step_20.las
@@ -1,0 +1,45 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1670.0000                :STOP DEPTH
+STEP    .M                 0.0000                :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -445,3 +445,49 @@ def test_write_large_depths():
     las2 = lasio.read('write_large_depths.las')
     os.remove('write_large_depths.las')
     assert np.all(las.curves[0].data == las2.curves[0].data)
+
+def test_write_single_step():
+    las = lasio.read(egfn("single_step_20.las"))
+    s = StringIO()
+    las.write(s, version=2)
+    s.seek(0)
+    assert s.read() == '''~Version ---------------------------------------------------
+VERS. 2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.  NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M                  1670.0 : START DEPTH
+STOP.M                  1670.0 : STOP DEPTH
+STEP.M                    None : STEP
+NULL.                  -999.25 : NULL VALUE
+COMP.     ANY OIL COMPANY INC. : COMPANY
+WELL.                  AAAAA_2 : WELL
+FLD .                  WILDCAT : FIELD
+LOC .           12-34-12-34W5M : LOCATION
+PROV.                  ALBERTA : PROVINCE
+SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
+DATE.                13-DEC-86 : LOG DATE
+UWI .         100123401234W500 : UNIQUE WELL ID
+~Curve Information -----------------------------------------
+DEPT.M                 : 1  DEPTH
+DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V  42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM 07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM 07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM 07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM 07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .   GEL CHEM : MUD TYPE
+BHT .DEGC   35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM    200.0 : BIT SIZE
+FD  .K/M3 1000.0 : FLUID DENSITY
+MATR.       SAND : NEUTRON MATRIX
+MDEN.     2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM  0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3 1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~ASCII -----------------------------------------------------
+ 1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+'''


### PR DESCRIPTION
This pull request contains a test case for the #286 pull request: Fixed error on writing single depth (edge case use) #286.  If accepted, maybe integrate them at the same time.

This pull request introduces a test file with a single depth and 0.000 step.  

Without the #286 pull content, the new test case will fail with 'E           IndexError: index 1 is out of bounds for axis 0 with size 1'

With the #286 pull content the test case will pass.

test command:
pytest tests/test_write.py::test_write_single_step