### PR TITLE
stack_curves method added to LASFile object

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 # Standard library packages
 import codecs
+from collections.abc import Sequence
 import csv
 import json
 import logging
@@ -720,16 +721,20 @@ class LASFile(object):
         Returns:
             2-D numpy array
         """
+        if isinstance(mnemonic, np.ndarray):
+            mnemonic = list(mnemonic)
+
         if (not mnemonic) or (not all([i for i in mnemonic])):
             raise ValueError('`mnemonic` must not contain empty element')
 
         keys = self.curves.keys()
         if isinstance(mnemonic, str):
             channels = [i for i in keys if i.startswith(mnemonic)] or [mnemonic]
-        elif isinstance(mnemonic, list):
-            channels = mnemonic
+        elif isinstance(mnemonic, Sequence):
+            channels = list(mnemonic)
         else:
-            raise TypeError('`mnemonic` argument must be str or list')
+            raise TypeError('`mnemonic` argument must be string or sequence')
+        print(channels)
 
         if not set(keys).issuperset(set(channels)):
             missing = ', '.join(set(channels).difference(set(keys)))

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -2,7 +2,12 @@ from __future__ import print_function
 
 # Standard library packages
 import codecs
-from collections.abc import Sequence
+
+try: # will work in Python 3
+    from collections.abc import Sequence
+except ImportError: # Support Python 2.7
+    from collections import Sequence
+
 import csv
 import json
 import logging

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -704,6 +704,43 @@ class LASFile(object):
                 str(name) for name in df.columns.values
             ]
         self.set_data(df_values, **kwargs)
+    
+    def stack_curves(self, curve_list=None, stub=None, sort_curves=True):
+        """Stack multi-channel curve data to a numpy 2D ndarray. Provide a 
+        list of curves or a stub name (prefix shared by all curves that will
+        be stacked). If `stub` and `curve_list` are both supplied, `stub`
+        is used.
+        
+        Keyword Arguments:
+            stub (str): Supply the first several characters of the channel
+                set to be stacked. 
+            curve_list (list): Or a list of the curves to be stacked
+            sort_curves (bool): Natural sort curves based on mnemonic prior 
+                to stacking.
+
+        Returns:
+            2-D numpy array
+        """
+        curves = self.curves.keys()
+        if stub:
+            channels = [i for i in curves if i.startswith(stub)]
+        elif curve_list:
+            channels = curve_list
+        if sort_curves:
+            channels.sort(key=self._sort_channels)
+        if channels:
+            indices = [curves.index(i) for i in channels]
+        if indices:
+            return self.data[:, indices]
+    
+    def _str_to_int(self, mnemonic):
+        if mnemonic.isdigit():
+            return int(mnemonic)
+        else:
+            return mnemonic
+
+    def _sort_channels(self, mnemonic):
+        return [self._str_to_int(i) for i in re.split(r'(\d+)', mnemonic)]
 
     @property
     def index(self):

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -705,42 +705,43 @@ class LASFile(object):
             ]
         self.set_data(df_values, **kwargs)
     
-    def stack_curves(self, curve_list=None, stub=None, sort_curves=True):
+    def stack_curves(self, mnemonic, sort_curves=True):
         """Stack multi-channel curve data to a numpy 2D ndarray. Provide a 
-        list of curves or a stub name (prefix shared by all curves that will
-        be stacked). If `stub` and `curve_list` are both supplied, `stub`
-        is used.
-        
+        stub name (prefix shared by all curves that will be stacked) or a 
+        list of curve mnemonic strings.          
+
         Keyword Arguments:
-            stub (str): Supply the first several characters of the channel
-                set to be stacked. 
-            curve_list (list): Or a list of the curves to be stacked
+            mnemonic (str or list): Supply the first several characters of
+                the channel set to be stacked. Alternatively, supply a list 
+                of the curve names (mnemonics strings) to be stacked.
             sort_curves (bool): Natural sort curves based on mnemonic prior 
                 to stacking.
 
         Returns:
             2-D numpy array
         """
-        curves = self.curves.keys()
-        if stub:
-            channels = [i for i in curves if i.startswith(stub)]
-        elif curve_list:
-            channels = curve_list
-        if sort_curves:
-            channels.sort(key=self._sort_channels)
-        if channels:
-            indices = [curves.index(i) for i in channels]
-        if indices:
-            return self.data[:, indices]
-    
-    def _str_to_int(self, mnemonic):
-        if mnemonic.isdigit():
-            return int(mnemonic)
-        else:
-            return mnemonic
+        if (not mnemonic) or (not all([i for i in mnemonic])):
+            raise ValueError('`mnemonic` must not contain empty element')
 
-    def _sort_channels(self, mnemonic):
-        return [self._str_to_int(i) for i in re.split(r'(\d+)', mnemonic)]
+        keys = self.curves.keys()
+        if isinstance(mnemonic, str):
+            channels = [i for i in keys if i.startswith(mnemonic)] or [mnemonic]
+        elif isinstance(mnemonic, list):
+            channels = mnemonic
+        else:
+            raise TypeError('`mnemonic` argument must be str or list')
+
+        if not set(keys).issuperset(set(channels)):
+            missing = ', '.join(set(channels).difference(set(keys)))
+            raise KeyError('{} not found in LAS curves.'.format(missing))
+
+        if sort_curves:
+            nat_sort = lambda x: \
+                [int(i) if i.isdigit() else i for i in re.split(r'(\d+)', x)]
+            channels.sort(key=nat_sort)
+
+        indices = [keys.index(i) for i in channels]
+        return self.data[:, indices]
 
     @property
     def index(self):

--- a/tests/examples/multi_channel.las
+++ b/tests/examples/multi_channel.las
@@ -1,0 +1,52 @@
+~VERSION INFORMATION
+VERS.           2.0   :CWLS Log ASCII Standard - VERSION 2.0
+WRAP.           NO    :One Line per depth step
+#--------------------------------------------------
+~WELL INFORMATION
+#MNEM.UNIT      DATA             DESCRIPTION
+#---- ------ --------------   -----------------------------
+STRT .F         7508.0       :START DEPTH     
+STOP .F         7506.0       :STOP DEPTH     
+STEP .F           -0.5       :STEP     
+NULL .          -999.25      :NULL VALUE
+COMP .        HIGHMOUNT EXPL & PROD TEXAS LLC          :COMPANY
+WELL .        UNIVERSITY 54-5 # 3                      :WELL
+CNTY .        SCHLEICHER                               :COUNTY
+STAT .        TEXAS                                    :STATE
+CTRY .        USA                                      :COUNTRY
+API  .        42-413-32879                             :API NUMBER
+#-----------------------------------------------------------------------------
+~PARAMETER INFORMATION
+#MNEM.UNIT    VALUE                      DESCRIPTION
+#---- -----   --------------------       ------------------------
+BHT  .DEGF     175.00000                 :Bottom Hole Temperature
+BS   .IN         7.87500                 :Bit Size
+#-----------------------------------------------------------------------------
+~CURVE INFORMATION
+#MNEM.UNIT   API CODE                                  DESCRIPTION
+#---- -----  --------                                  -----------------------
+DEPT .F                                                :DEPTH (BOREHOLE) {F10.1}
+BFV  .CFCF                                             :Bound Fluid Volume {F11.4}
+CBP1 .CFCF                                             :CMR Bin Porosity 1 {F11.4}
+CBP2 .CFCF                                             :CMR Bin Porosity 2 {F11.4}
+CBP3 .CFCF                                             :CMR Bin Porosity 3 {F11.4}
+CBP4 .CFCF                                             :CMR Bin Porosity 4 {F11.4}
+CBP5 .CFCF                                             :CMR Bin Porosity 5 {F11.4}
+CBP6 .CFCF                                             :CMR Bin Porosity 6 {F11.4}
+CBP7 .CFCF                                             :CMR Bin Porosity 7 {F11.4}
+CBP8 .CFCF                                             :CMR Bin Porosity 8 {F11.4}
+CFTC .HZ                                               :Corrected Far Thermal Count Rate {F11.4}
+CMFF .CFCF                                             :CMR Free Fluid {F11.4}
+CMFF_SIG.CFCF                                          :Standard Deviation of CMR Free Fluid {F11.4}
+CMR_PHI_CONV.                                          :CMR Porosity Conversion factor {F11.4}
+CMRP_3MS.CFCF                                          :CMR Porosity with T2 values greater than 3 ms {F11.4}
+#-----------------------------------------------------------------------------
+# 
+#     DEPT       BFV        CBP1       CBP2       CBP3       CBP4       CBP5       CBP6       CBP7       CBP8       CFTC       CMFF     CMFF_SIG  CMR_PHI_CO  CMRP_3MS
+#                                                                                                                                                 NV
+~A  
+    7508.0     0.0201     0.0144     0.0055     0.0001     0.0000     0.0000     0.0000     0.0000     0.0003   841.0595     0.0004     0.0059     0.0007     0.0005  
+    7507.5     0.0095     0.0044     0.0045     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000   841.0595     0.0000     0.0059     0.0007     0.0006  
+    7507.0     0.0155     0.0020     0.0119     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000   841.0595     0.0000     0.0058     0.0007     0.0016  
+    7506.5     0.0101     0.0006     0.0064     0.0031     0.0000     0.0000     0.0000     0.0001     0.0010   841.0595     0.0011     0.0059     0.0007     0.0043  
+    7506.0     0.0072     0.0008     0.0038     0.0026     0.0000     0.0000     0.0000     0.0002     0.0020   841.0595     0.0022     0.0059     0.0007     0.0048  

--- a/tests/examples/multi_channel_natural_sorting.las
+++ b/tests/examples/multi_channel_natural_sorting.las
@@ -1,0 +1,52 @@
+~VERSION INFORMATION
+VERS.           2.0   :CWLS Log ASCII Standard - VERSION 2.0
+WRAP.           NO    :One Line per depth step
+#--------------------------------------------------
+~WELL INFORMATION
+#MNEM.UNIT      DATA             DESCRIPTION
+#---- ------ --------------   -----------------------------
+STRT .F         7508.0       :START DEPTH     
+STOP .F         7506.0       :STOP DEPTH     
+STEP .F           -0.5       :STEP     
+NULL .          -999.25      :NULL VALUE
+COMP .        HIGHMOUNT EXPL & PROD TEXAS LLC          :COMPANY
+WELL .        UNIVERSITY 54-5 # 3                      :WELL
+CNTY .        SCHLEICHER                               :COUNTY
+STAT .        TEXAS                                    :STATE
+CTRY .        USA                                      :COUNTRY
+API  .        42-413-32879                             :API NUMBER
+#-----------------------------------------------------------------------------
+~PARAMETER INFORMATION
+#MNEM.UNIT    VALUE                      DESCRIPTION
+#---- -----   --------------------       ------------------------
+BHT  .DEGF     175.00000                 :Bottom Hole Temperature
+BS   .IN         7.87500                 :Bit Size
+#-----------------------------------------------------------------------------
+~CURVE INFORMATION
+#MNEM.UNIT   API CODE                                  DESCRIPTION
+#---- -----  --------                                  -----------------------
+DEPT .F                                                :DEPTH (BOREHOLE) {F10.1}
+BFV  .CFCF                                             :Bound Fluid Volume {F11.4}
+CBP1 .CFCF                                             :CMR Bin Porosity 1 {F11.4}
+CBP20 .CFCF                                             :CMR Bin Porosity 20 {F11.4}
+CBP13 .CFCF                                             :CMR Bin Porosity 13 {F11.4}
+CBP11 .CFCF                                             :CMR Bin Porosity 11 {F11.4}
+CBP55 .CFCF                                             :CMR Bin Porosity 55 {F11.4}
+CBP103 .CFCF                                             :CMR Bin Porosity 103 {F11.4}
+CBP2003 .CFCF                                             :CMR Bin Porosity 2003 {F11.4}
+CBP543 .CFCF                                             :CMR Bin Porosity 543 {F11.4}
+CFTC .HZ                                               :Corrected Far Thermal Count Rate {F11.4}
+CMFF .CFCF                                             :CMR Free Fluid {F11.4}
+CMFF_SIG.CFCF                                          :Standard Deviation of CMR Free Fluid {F11.4}
+CMR_PHI_CONV.                                          :CMR Porosity Conversion factor {F11.4}
+CMRP_3MS.CFCF                                          :CMR Porosity with T2 values greater than 3 ms {F11.4}
+#-----------------------------------------------------------------------------
+# 
+#     DEPT       BFV        CBP1      CBP20      CBP13      CBP11      CBP55     CBP103    CBP2003     CBP543       CFTC       CMFF     CMFF_SIG  CMR_PHI_CO  CMRP_3MS
+#                                                                                                                                                 NV
+~A  
+    7508.0     0.0201     0.0144     0.0020     0.0013     0.0011     0.0055     0.0103     0.2003     0.0543   841.0595     0.0004     0.0059     0.0007     0.0005  
+    7507.5     0.0095     0.0044     0.0045     0.0006     0.0000     0.0000     0.0000     0.0000     0.0000   841.0595     0.0000     0.0059     0.0007     0.0006  
+    7507.0     0.0155     0.0020     0.0119     0.0016     0.0000     0.0000     0.0000     0.0000     0.0000   841.0595     0.0000     0.0058     0.0007     0.0016  
+    7506.5     0.0101     0.0006     0.0064     0.0031     0.0000     0.0000     0.0000     0.0001     0.0010   841.0595     0.0011     0.0059     0.0007     0.0043  
+    7506.0     0.0072     0.0008     0.0038     0.0026     0.0000     0.0000     0.0000     0.0002     0.0020   841.0595     0.0022     0.0059     0.0007     0.0048  

--- a/tests/examples/multi_channel_out_of_order.las
+++ b/tests/examples/multi_channel_out_of_order.las
@@ -1,0 +1,52 @@
+~VERSION INFORMATION
+VERS.           2.0   :CWLS Log ASCII Standard - VERSION 2.0
+WRAP.           NO    :One Line per depth step
+#--------------------------------------------------
+~WELL INFORMATION
+#MNEM.UNIT      DATA             DESCRIPTION
+#---- ------ --------------   -----------------------------
+STRT .F         7508.0       :START DEPTH     
+STOP .F         7506.0       :STOP DEPTH     
+STEP .F           -0.5       :STEP     
+NULL .          -999.25      :NULL VALUE
+COMP .        HIGHMOUNT EXPL & PROD TEXAS LLC          :COMPANY
+WELL .        UNIVERSITY 54-5 # 3                      :WELL
+CNTY .        SCHLEICHER                               :COUNTY
+STAT .        TEXAS                                    :STATE
+CTRY .        USA                                      :COUNTRY
+API  .        42-413-32879                             :API NUMBER
+#-----------------------------------------------------------------------------
+~PARAMETER INFORMATION
+#MNEM.UNIT    VALUE                      DESCRIPTION
+#---- -----   --------------------       ------------------------
+BHT  .DEGF     175.00000                 :Bottom Hole Temperature
+BS   .IN         7.87500                 :Bit Size
+#-----------------------------------------------------------------------------
+~CURVE INFORMATION
+#MNEM.UNIT   API CODE                                  DESCRIPTION
+#---- -----  --------                                  -----------------------
+DEPT .F                                                :DEPTH (BOREHOLE) {F10.1}
+BFV  .CFCF                                             :Bound Fluid Volume {F11.4}
+CBP3 .CFCF                                             :CMR Bin Porosity 3 {F11.4}
+CBP5 .CFCF                                             :CMR Bin Porosity 5 {F11.4}
+CBP1 .CFCF                                             :CMR Bin Porosity 1 {F11.4}
+CBP7 .CFCF                                             :CMR Bin Porosity 7 {F11.4}
+CBP2 .CFCF                                             :CMR Bin Porosity 2 {F11.4}
+CBP4 .CFCF                                             :CMR Bin Porosity 4 {F11.4}
+CBP8 .CFCF                                             :CMR Bin Porosity 8 {F11.4}
+CBP6 .CFCF                                             :CMR Bin Porosity 6 {F11.4}
+CFTC .HZ                                               :Corrected Far Thermal Count Rate {F11.4}
+CMFF .CFCF                                             :CMR Free Fluid {F11.4}
+CMFF_SIG.CFCF                                          :Standard Deviation of CMR Free Fluid {F11.4}
+CMR_PHI_CONV.                                          :CMR Porosity Conversion factor {F11.4}
+CMRP_3MS.CFCF                                          :CMR Porosity with T2 values greater than 3 ms {F11.4}
+#-----------------------------------------------------------------------------
+# 
+#     DEPT       BFV        CBP3       CBP5       CBP1       CBP7       CBP2       CBP4      CBP8      CBP6         CFTC       CMFF     CMFF_SIG  CMR_PHI_CO  CMRP_3MS
+#                                                                                                                                                 NV
+~A                                                                                                              
+    7508.0     0.0201     0.0001     0.0000     0.0144     0.0000     0.0055     0.0000    0.0003    0.0000     841.0595     0.0004     0.0059     0.0007     0.0005  
+    7507.5     0.0095     0.0006     0.0000     0.0044     0.0000     0.0045     0.0000    0.0000    0.0000     841.0595     0.0000     0.0059     0.0007     0.0006  
+    7507.0     0.0155     0.0016     0.0000     0.0020     0.0000     0.0119     0.0000    0.0000    0.0000     841.0595     0.0000     0.0058     0.0007     0.0016  
+    7506.5     0.0101     0.0031     0.0000     0.0006     0.0001     0.0064     0.0000    0.0010    0.0000     841.0595     0.0011     0.0059     0.0007     0.0043  
+    7506.0     0.0072     0.0008     0.0038     0.0026     0.0000     0.0000     0.0000     0.0002     0.0020   841.0595     0.0022     0.0059     0.0007     0.0048  

--- a/tests/test_stack_curves.py
+++ b/tests/test_stack_curves.py
@@ -38,7 +38,7 @@ def test_stack_curves_with_ndarray():
     las = lasio.read(egfn("multi_channel.las"))
     sc = las.stack_curves(np.array(['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8']))
     assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
-
+    
 
 def test_stack_unordered_curves_with_list():
     las = lasio.read(egfn("multi_channel_out_of_order.las"))

--- a/tests/test_stack_curves.py
+++ b/tests/test_stack_curves.py
@@ -1,0 +1,53 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+import numpy as np
+
+import lasio
+
+test_dir = os.path.dirname(__file__)
+
+egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+
+
+def test_stack_curves_with_stub():
+    las = lasio.read(egfn("multi_channel.las"))
+    sc = las.stack_curves(stub='CBP')
+    assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
+
+
+def test_stack_unordered_curves_with_stub():
+    las = lasio.read(egfn("multi_channel_out_of_order.las"))
+    sc = las.stack_curves(stub='CBP')
+    assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
+
+
+def test_stack_unordered_natural_sorting_with_stub():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    sc = las.stack_curves(stub='CBP')
+    assert (sc[0] == np.array([0.0144, 0.0011, 0.0013, 0.002 , 0.0055, 0.0103, 0.0543, 0.2003])).all()
+
+
+def test_stack_curves_with_list():
+    las = lasio.read(egfn("multi_channel.las"))
+    sc = las.stack_curves(curve_list=['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8'])
+    assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
+
+
+def test_stack_unordered_curves_with_list():
+    las = lasio.read(egfn("multi_channel_out_of_order.las"))
+    sc = las.stack_curves(curve_list=['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8'])
+    assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
+
+
+def test_stack_unordered_natural_sorting_with_list():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    sc = las.stack_curves(['CBP13', 'CBP2003', 'CBP11', 'CBP1', 'CBP103', 'CBP543', 'CBP20', 'CBP55'])
+    assert (sc[0] == np.array([0.0144, 0.0011, 0.0013, 0.002 , 0.0055, 0.0103, 0.0543, 0.2003])).all()
+
+
+def test_stack_unordered_natural_no_sort_with_list():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    sc = las.stack_curves(['CBP13', 'CBP2003', 'CBP11', 'CBP1', 'CBP103', 'CBP543', 'CBP20', 'CBP55'],
+        sort_curves=False)
+    assert (sc[0] == np.array([0.0013, 0.2003, 0.0011, 0.0144, 0.0103, 0.0543, 0.002 , 0.0055])).all()

--- a/tests/test_stack_curves.py
+++ b/tests/test_stack_curves.py
@@ -12,31 +12,31 @@ egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
 
 def test_stack_curves_with_stub():
     las = lasio.read(egfn("multi_channel.las"))
-    sc = las.stack_curves(stub='CBP')
+    sc = las.stack_curves('CBP')
     assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
 
 
 def test_stack_unordered_curves_with_stub():
     las = lasio.read(egfn("multi_channel_out_of_order.las"))
-    sc = las.stack_curves(stub='CBP')
+    sc = las.stack_curves('CBP')
     assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
 
 
 def test_stack_unordered_natural_sorting_with_stub():
     las = lasio.read(egfn("multi_channel_natural_sorting.las"))
-    sc = las.stack_curves(stub='CBP')
+    sc = las.stack_curves('CBP')
     assert (sc[0] == np.array([0.0144, 0.0011, 0.0013, 0.002 , 0.0055, 0.0103, 0.0543, 0.2003])).all()
 
 
 def test_stack_curves_with_list():
     las = lasio.read(egfn("multi_channel.las"))
-    sc = las.stack_curves(curve_list=['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8'])
+    sc = las.stack_curves(['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8'])
     assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
 
 
 def test_stack_unordered_curves_with_list():
     las = lasio.read(egfn("multi_channel_out_of_order.las"))
-    sc = las.stack_curves(curve_list=['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8'])
+    sc = las.stack_curves(['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8'])
     assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
 
 
@@ -51,3 +51,41 @@ def test_stack_unordered_natural_no_sort_with_list():
     sc = las.stack_curves(['CBP13', 'CBP2003', 'CBP11', 'CBP1', 'CBP103', 'CBP543', 'CBP20', 'CBP55'],
         sort_curves=False)
     assert (sc[0] == np.array([0.0013, 0.2003, 0.0011, 0.0144, 0.0103, 0.0543, 0.002 , 0.0055])).all()
+
+
+def test_stack_empty_string():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    with pytest.raises(ValueError):
+        las.stack_curves("")
+
+
+def test_stack_empty_list():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    with pytest.raises(ValueError):
+        las.stack_curves([])
+        
+
+def test_stack_nothing():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    with pytest.raises(TypeError):
+        las.stack_curves()
+        
+
+def test_stack_list_with_empty_element():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    with pytest.raises(ValueError):
+        las.stack_curves(['CBP1', ''])
+        
+
+def test_stack_mnemonic_not_in_LAS():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    with pytest.raises(KeyError) as e:
+        las.stack_curves('TCMR')
+    assert e.value.args[0] == 'TCMR not found in LAS curves.'
+
+
+def test_stack_mnemonics_in_list_not_in_LAS():
+    las = lasio.read(egfn("multi_channel_natural_sorting.las"))
+    with pytest.raises(KeyError) as e:
+        las.stack_curves(['CBP1', 'CBP13', 'KTIM', 'TCMR'])
+    assert e.value.args[0] == 'TCMR, KTIM not found in LAS curves.'

--- a/tests/test_stack_curves.py
+++ b/tests/test_stack_curves.py
@@ -34,6 +34,12 @@ def test_stack_curves_with_list():
     assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
 
 
+def test_stack_curves_with_ndarray():
+    las = lasio.read(egfn("multi_channel.las"))
+    sc = las.stack_curves(np.array(['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8']))
+    assert (sc[0] == np.array([0.0144, 0.0055, 0.0001, 0.    , 0.    , 0.    , 0.    , 0.0003])).all()
+
+
 def test_stack_unordered_curves_with_list():
     las = lasio.read(egfn("multi_channel_out_of_order.las"))
     sc = las.stack_curves(['CBP1', 'CBP2', 'CBP3', 'CBP4', 'CBP5', 'CBP6', 'CBP7', 'CBP8'])

--- a/tests/test_stack_curves.py
+++ b/tests/test_stack_curves.py
@@ -88,4 +88,5 @@ def test_stack_mnemonics_in_list_not_in_LAS():
     las = lasio.read(egfn("multi_channel_natural_sorting.las"))
     with pytest.raises(KeyError) as e:
         las.stack_curves(['CBP1', 'CBP13', 'KTIM', 'TCMR'])
-    assert e.value.args[0] == 'TCMR, KTIM not found in LAS curves.'
+    assert (e.value.args[0] == 'TCMR, KTIM not found in LAS curves.') or \
+        (e.value.args[0] == 'KTIM, TCMR not found in LAS curves.')


### PR DESCRIPTION
This PR adds a method to the LASFile object for stacking multi-channel log data as requested in issue #284. 

The method can be fed a curve mnemonic list or a "stub" (a term i've seen used in pandas). If a curve mnemonic list is fed to the method, those curves will be stacked. If a "stub" is supplied, for example `stub='AWBK'`, the method will retrieve all curves with that prefix and stack those. 

The method sorts the curve mnemonics using "natural sorting" (`1, 2, 3, 4, 5, 6, 7, 8, 9, 10` instead of `1, 10, 2, 3, 4, 5, 6, 7, 8, 9`). Sorting can be turned off with `sort_curve=False`.

Also added some tests and example logs.