### PR TITLE
Issue #277 read pathlib path obj

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -7,7 +7,6 @@ import traceback
 
 import numpy as np
 
-from pathlib import Path
 from . import defaults
 
 # Convoluted import for StringIO in order to support:
@@ -47,11 +46,18 @@ URL_REGEXP = re.compile(
 )
 
 def check_for_path_obj(file_ref):
+    """Check if file_ref is a pathlib.Path object.
+
+    If file_ref is a pathlib.Path object, then return its absolute file 
+    path as a string so it will get processed as other string filenames.
+
+    If pathlib is not available, do nothing and return file_ref.
+
     """
-    If file_ref is a pathlib.Path object,
-    then return its absolute file path as a string so
-    it will get processed as other string filenames.
-    """
+    try:
+        from pathlib import Path
+    except ImportError:
+        return file_ref
 
     if isinstance(file_ref, Path):
         return file_ref.absolute().__str__()

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -64,6 +64,9 @@ def open_file(file_ref, **encoding_kwargs):
         was used to decode it (if it were read from disk).
 
     """
+
+    # TODO: Add condition for pathlib.Path objects
+
     encoding = None
     if isinstance(file_ref, str):  # file_ref != file-like object, so what is it?
         lines = file_ref.splitlines()

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -7,6 +7,7 @@ import traceback
 
 import numpy as np
 
+from pathlib import Path
 from . import defaults
 
 # Convoluted import for StringIO in order to support:
@@ -45,6 +46,12 @@ URL_REGEXP = re.compile(
     re.IGNORECASE,
 )
 
+def check_for_path_obj(file_ref):
+    if isinstance(file_ref, Path):
+        return file_ref.open()
+    else:
+        return file_ref
+
 
 def open_file(file_ref, **encoding_kwargs):
     """Open a file if necessary.
@@ -65,7 +72,7 @@ def open_file(file_ref, **encoding_kwargs):
 
     """
 
-    # TODO: Add condition for pathlib.Path objects
+    file_ref = check_for_path_obj(file_ref)
 
     encoding = None
     if isinstance(file_ref, str):  # file_ref != file-like object, so what is it?

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -47,8 +47,14 @@ URL_REGEXP = re.compile(
 )
 
 def check_for_path_obj(file_ref):
+    """
+    If file_ref is a pathlib.Path object,
+    then return its absolute file path as a string so
+    it will get processed as other string filenames.
+    """
+
     if isinstance(file_ref, Path):
-        return file_ref.open()
+        return file_ref.absolute().__str__()
     else:
         return file_ref
 

--- a/optional-packages.txt
+++ b/optional-packages.txt
@@ -7,3 +7,4 @@ pytest>=3.6
 pytest-cov
 coverage
 codecov
+pathlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 numpy
-pathlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+pathlib

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -5,6 +5,8 @@ import codecs
 
 import pytest
 
+from pathlib import Path
+
 from lasio import read
 
 egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
@@ -23,4 +25,18 @@ def test_utf16le_cchardet_fails():
 def test_utf16bebom_cchardet(): las = read(egfn("encodings_utf16bebom.las"), autodetect_encoding='cchardet')
 def test_iso88591_cchardet(): las = read(egfn("encodings_iso88591.las"), autodetect_encoding='cchardet')
 def test_cp1252_cchardet(): las = read(egfn("encodings_cp1252.las"), autodetect_encoding='cchardet')
+
+"""
+Verify encodings for pathlib.Path objects
+"""
+def test_pathlib_utf8_cchardet(): las = read(Path(egfn("encodings_utf8.las")), autodetect_encoding='cchardet')
+def test_pathlib_utf8wbom_cchardet(): las = read(Path(egfn("encodings_utf8wbom.las")), autodetect_encoding='cchardet')
+def test_pathlib_utf16lebom_cchardet(): las = read(Path(egfn("encodings_utf16lebom.las")), autodetect_encoding='cchardet')
+def test_pathlib_utf16le_specified_ok(): las = read(Path(egfn("encodings_utf16le.las")), encoding='UTF-16-LE')
+def test_pathlib_utf16le_cchardet_fails(): 
+    with pytest.raises(Exception):
+        las = read(Path(egfn("encodings_utf16le.las")), autodetect_encoding='cchardet')
+def test_pathlib_utf16bebom_cchardet(): las = read(Path(egfn("encodings_utf16bebom.las")), autodetect_encoding='cchardet')
+def test_pathlib_iso88591_cchardet(): las = read(Path(egfn("encodings_iso88591.las")), autodetect_encoding='cchardet')
+def test_pathlib_cp1252_cchardet(): las = read(Path(egfn("encodings_cp1252.las")), autodetect_encoding='cchardet')
 

--- a/tests/test_open_file.py
+++ b/tests/test_open_file.py
@@ -1,6 +1,10 @@
 import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+
 import pytest
+
+# TODO: decide how to handle python 2.7 versions
+from pathlib import Path
 
 from lasio import read
 
@@ -8,6 +12,19 @@ test_dir = os.path.dirname(__file__)
 
 egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
 
+def test_open_pathlib_object():
+    print('\nEGFN', egfn("sample.las"))
+    print('INSTANCE-OF-PATH: [', isinstance(Path(egfn("sample.las")), Path), ']')
+    print('TYPE: [', type(Path(egfn("sample.las"))), ']')
+    """
+    print(dir(Path(egfn("sample.las"))))
+    print(Path(egfn("sample.las")).joinpath())
+    print(Path(egfn("sample.las")).absolute())
+    print(Path(egfn("sample.las")).home())
+    print(Path(egfn("sample.las")).read_text())
+    l = read(Path(egfn("sample.las")).read_text())
+    """
+    l = read(Path(egfn("sample.las")))
 
 def test_open_url():
     l = read("https://raw.githubusercontent.com/kinverarity1/"

--- a/tests/test_open_file.py
+++ b/tests/test_open_file.py
@@ -3,7 +3,7 @@ import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import pytest
 
-# TODO: decide how to handle python 2.7 versions
+# pathlib for python2 is installed via pip install -r requirements.txt
 from pathlib import Path
 
 from lasio import read
@@ -13,17 +13,6 @@ test_dir = os.path.dirname(__file__)
 egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
 
 def test_open_pathlib_object():
-    print('\nEGFN', egfn("sample.las"))
-    print('INSTANCE-OF-PATH: [', isinstance(Path(egfn("sample.las")), Path), ']')
-    print('TYPE: [', type(Path(egfn("sample.las"))), ']')
-    """
-    print(dir(Path(egfn("sample.las"))))
-    print(Path(egfn("sample.las")).joinpath())
-    print(Path(egfn("sample.las")).absolute())
-    print(Path(egfn("sample.las")).home())
-    print(Path(egfn("sample.las")).read_text())
-    l = read(Path(egfn("sample.las")).read_text())
-    """
     l = read(Path(egfn("sample.las")))
 
 def test_open_url():


### PR DESCRIPTION
### draft proposed solution for issue #277. 
 It adds a small function in reader.py to check if the file_ref instances is a descendant of the pathlib.Path object/class.  It if it is then it returns the a text stream via pathlib.Path.open().  If the file_ref is not a related to pathlib.Path it is passed through unchanged.

### python2 and python3
For this to work with python2.*, the pathlib module is added to requirements.txt.  This has a minimal impact on Python3 in that it it will install the pip pathlib module even though Python3 includes pathlib in its default modules.  

### new test
pytest -s -v tests/test_open_file.py::test_open_pathlib_object

