### PR TITLE
Add lasio.examples module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ CODE_OF_CONDUCT.rst
 
 .vscode*
 coverage.xml*
+htmlcov

--- a/lasio/examples.py
+++ b/lasio/examples.py
@@ -112,5 +112,5 @@ def get_local_examples_path():
     import lasio
 
     return os.path.join(
-        os.path.abspath(os.path.abspath(lasio.__file__)), "tests", "examples"
+        os.path.dirname(os.path.dirname(lasio.__file__)), "tests", "examples"
     )

--- a/lasio/examples.py
+++ b/lasio/examples.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 # Convoluted import for StringIO in order to support:
@@ -21,6 +22,9 @@ else:
 from .las import LASFile
 
 
+logger = logging.getLogger(__name__)
+
+
 def open(filename, **kwargs):
     """Open an example LAS file from lasio's test suite.
 
@@ -31,7 +35,7 @@ def open(filename, **kwargs):
 
     Other keyword arguments are passed to `lasio.LASFile`. If lasio has been
     installed locally from source, then the local version of the example file
-    will be opened. If lasio has not been installed from source then the LAS 
+    will be opened. If lasio has not been installed from source then the LAS
     file will be downloaded from GitHub.
 
     Returns: LASFile object

--- a/lasio/examples.py
+++ b/lasio/examples.py
@@ -1,0 +1,116 @@
+import os
+
+# Convoluted import for StringIO in order to support:
+#
+# - Python 3 - io.StringIO
+# - Python 2 (optimized) - cStringIO.StringIO
+# - Python 2 (all) - StringIO.StringIO
+
+try:
+    import cStringIO as StringIO
+except ImportError:
+    try:  # cStringIO not available on this system
+        import StringIO
+    except ImportError:  # Python 3
+        from io import StringIO
+    else:
+        from StringIO import StringIO
+else:
+    from StringIO import StringIO
+
+from .las import LASFile
+
+
+def open(filename, **kwargs):
+    """Open an example LAS file from lasio's test suite.
+
+    Args:
+        filename (str): forward-slash separated filename of a LAS file from
+            lasio's test suite, starting from the "tests/examples" subfolder
+            e.g. "1001178549.las" or "2.0/sample_2.0.las"
+
+    Other keyword arguments are passed to `lasio.LASFile`. If lasio has been
+    installed locally from source, then the local version of the example file
+    will be opened. If lasio has not been installed from source then the LAS 
+    file will be downloaded from GitHub.
+
+    Returns: LASFile object
+
+    """
+    local_path = get_local_examples_path()
+    if os.path.isdir(local_path):
+        return open_local_example(filename, **kwargs)
+    else:
+        return open_github_example(filename, **kwargs)
+
+
+def open_github_example(
+    filename,
+    url_prefix="https://raw.githubusercontent.com/kinverarity1/lasio/master/tests/examples/",
+    **kwargs
+):
+    """Open an example LAS file from lasio's test suite on GitHub
+
+    Args:
+        filename (str): forward-slash separated filename of a LAS file from
+            lasio's test suite, starting from the "tests/examples" subfolder
+            e.g. "1001178549.las" or "2.0/sample_2.0.las"
+
+    Other keyword arguments are passed to `lasio.LASFile`.
+
+    Returns: LASFile object
+
+    """
+    url = url_prefix + filename
+    try:
+        import urllib2
+
+        response = urllib2.urlopen(url)
+        encoding = response.headers.getparam("charset")
+        file_ref = StringIO(response.read())
+        logger.debug("Retrieved data had encoding {}".format(encoding))
+    except ImportError:
+        import urllib.request
+
+        response = urllib.request.urlopen(url)
+        if response.headers.get_content_charset() is None:
+            if "encoding" in encoding_kwargs:
+                encoding = encoding_kwargs["encoding"]
+            else:
+                encoding = "utf-8"
+        else:
+            encoding = response.headers.get_content_charset()
+        file_ref = StringIO(response.read().decode(encoding))
+    return LASFile(file_ref, **kwargs)
+
+
+def open_local_example(filename, **kwargs):
+    """Open an example LAS file from lasio's test suite.
+
+    Args:
+        filename (str): forward-slash separated filename of a LAS file from
+            lasio's test suite, starting from the "tests/examples" subfolder
+            e.g. "1001178549.las" or "2.0/sample_2.0.las"
+
+    Other keyword arguments are passed to `lasio.LASFile`. If lasio has not been
+    installed from source then an exception will be raised.
+
+    Returns: LASFile object
+
+    """
+    examples_path = get_local_examples_path()
+    return LASFile(os.path.join(examples_path, *filename.split("/")), **kwargs)
+
+
+def get_local_examples_path():
+    """Return the path to the examples from lasio's test suite, if it is
+    installed locally.
+
+    Returns: path as str.
+
+    """
+    import lasio
+
+    return os.path.join(
+        os.path.abspath(os.path.abspath(lasio.__file__)), "tests", "examples"
+    )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,29 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+import numpy as np
+
+import lasio.examples
+
+test_dir = os.path.dirname(__file__)
+
+egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+
+
+def test_local_path():
+	assert os.path.isdir(lasio.examples.get_local_examples_path())
+
+def test_local():
+	l1 = lasio.read(egfn("sample.las"))
+	l2 = lasio.examples.open_local_example("sample.las")
+	assert l1._text == l2._text
+
+def test_github():
+	l1 = lasio.read(egfn("sample.las"))
+	l2 = lasio.examples.open_github_example("sample.las")
+	assert l1._text == l2._text
+
+def test_open():
+	l1 = lasio.read(egfn("sample.las"))
+	l2 = lasio.examples.open("sample.las")
+	assert l1._text == l2._text


### PR DESCRIPTION
This adds a module `lasio.examples` for loading example LAS files from the test suite:

```
In [1]: import lasio.examples
In [2]: lasio.examples.open("1001178549.las")
Out[2]: <lasio.las.LASFile at 0x1fa4f04e748>
```

Forward slashes should be used as path separaters, even on Windows:

```
In [14]: lasio.examples.open("1.2/sample_big.las")
Out[14]: <lasio.las.LASFile at 0x1fa50c7b288>
```

It uses the installed version of lasio (only works if you install from source) to load the example file from disk. These are the functions used behind the scenes:

```
In [12]: lasio.examples.get_local_examples_path()
Out[12]: 'C:\\Users\\kinve\\code\\lasio\\tests\\examples'
In [13]: lasio.examples.open_local_example("2.0/sample_2.0.las")
Out[13]: <lasio.las.LASFile at 0x1fa4c9ce2c8>
```

If you do not have a source-installed version of lasio, it will transparently fetch the file from GitHub if you have a working internet connection:

```
In [5]: lasio.examples.open_github_example("6038187_v1.2.las")
Out[5]: <lasio.las.LASFile at 0x1fa509b57c8>
```