### PR TITLE
Issue #264: enable parsing periods in mnemonic field for Curve Section.

### DIFF
--- a/tests/examples/1.2/issue-264-dot-delimiter.las
+++ b/tests/examples/1.2/issue-264-dot-delimiter.las
@@ -1,0 +1,43 @@
+~VERSION INFORMATION
+ VERS.                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
+ WRAP.                  NO:   ONE LINE PER DEPTH STEP
+~WELL INFORMATION BLOCK
+#MNEM.UNIT       DATA TYPE    INFORMATION
+#---------    -------------   ------------------------------
+ STRT.M        1670.000000:
+ STOP.M        1660.000000:
+ STEP.M            -0.1250:
+ NULL.           -999.2500:
+ COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ WELL.                WELL:   ANY ET AL OIL WELL #12
+ FLD .               FIELD:   EDAM
+ LOC .            LOCATION:   A9-16-49-20W3M
+ PROV.            PROVINCE:   SASKATCHEWAN
+ SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY LTD.
+ DATE.            LOG DATE:   25-DEC-1988
+ UWI .      UNIQUE WELL ID:   100091604920W300
+~CURVE INFORMATION
+#MNEM.UNIT      API CODE      CURVE DESCRIPTION
+#---------    -------------   ------------------------------
+DEPT.FT                        : DEPTH
+Speed.M/MIN                    : Speed
+Cond..MS/M                     : Cond.
+Gamma.CPS                      : Gamma
+I. Res..OHM-M                  : I. Res.
+~PARAMETER INFORMATION
+#MNEM.UNIT        VALUE       DESCRIPTION
+#---------    -------------   ------------------------------
+ BHT .DEGC         35.5000:   BOTTOM HOLE TEMPERATURE
+ BS  .MM          200.0000:   BIT SIZE
+ FD  .K/M3       1000.0000:   FLUID DENSITY
+ MATR.              0.0000:   NEUTRON MATRIX(0=LIME,1=SAND,2=DOLO)
+ MDEN.           2710.0000:   LOGGING MATRIX DENSITY
+ RMF .OHMM          0.2160:   MUD FILTRATE RESISTIVITY
+ DFD .K/M3       1525.0000:   DRILL FLUID DENSITY
+~Other
+     Note: The logging tools became stuck at 625 meters causing the data
+	   between 625 meters and 615 meters to be invalid.
+~A  DEPTH  Speed       Cond.     Gamma     I. Res.
+1670.000   123.450 2550.000    0.450  123.450
+1669.875   123.450 2550.000    0.450  123.450
+1669.750   123.450 2550.000    0.450  123.450

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -378,7 +378,7 @@ def test_read_incorrect_shape():
     with pytest.raises(ValueError):
         lasio.read(egfn("sample_lastcolblanked.las"))
 
-def test_dot_delmiter_issue_264():
+def test_dot_delimiter_issue_264():
     l = lasio.read(stegfn("1.2", "issue-264-dot-delimiter.las"))
     assert [c.mnemonic for c in l.curves] == [
         "DEPT",

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -377,3 +377,28 @@ def test_index_unit_equals_m():
 def test_read_incorrect_shape():
     with pytest.raises(ValueError):
         lasio.read(egfn("sample_lastcolblanked.las"))
+
+def test_dot_delmiter_issue_264():
+    l = lasio.read(stegfn("1.2", "issue-264-dot-delimiter.las"))
+    assert [c.mnemonic for c in l.curves] == [
+        "DEPT",
+        "SPEED",
+        "COND.",
+        "GAMMA",
+        "I. RES.",
+    ]
+    assert [c.unit for c in l.curves] == [
+        "FT",
+        "M/MIN",
+        "MS/M",
+        "CPS",
+        "OHM-M",
+    ]
+    assert [c.value for c in l.curves] == [
+        "",
+        "",
+        "",
+        "",
+        "",
+    ]
+


### PR DESCRIPTION
Here is a proposed fix for:    
Issue #264: 'What happens when periods are in both mnemonic and unit?'

It adds a test case based on the example data in the #264 issue. All 192 tests pass on python 3.7.5.

To run the specific test:
pytest -s -v tests/test_read.py::test_dot_delmiter_issue_264 

The test file is:
tests/examples/1.2/issue-264-dot-delimiter.las

This proposed solution looks in the Curve section data for a case of 'double dots' before the description section.  If 'double dots' are found then the regular expression to parse the fields is adjusted so that the first dot is becomes a period in the mnemonic field and the second dot act as the delimiter between the mnemonic field and the unit field.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,

DC
