### PR TITLE
Issue 201:Allow time colons before colon delimiter

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -731,8 +731,8 @@ def read_header_line(line, pattern=None, section_name=None):
 
     # Default regular expressions for name, unit, value and desc fields
     name_re = r"\.?(?P<name>[^.]*)\."
-    unit_re = r"(?P<unit>[^\s:]*)"
-    value_re = r"(?P<value>[^:]*):"
+    unit_re = r"(?P<unit>[^\s]*)"
+    value_re = r"(?P<value>.*):"
     desc_re = r"(?P<descr>.*)"
 
     # Alternate regular expressions for special cases

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -737,8 +737,7 @@ def read_header_line(line, pattern=None, section_name=None):
 
     # Alternate regular expressions for special cases
     value_without_colon_delimiter_re = r"(?P<value>[^:]*)"
-    value_re_for_param_section =
-        r"(?P<value>.*?)(?:(?<!( [0-2][0-3]| hh| HH)):(?!([0-5][0-9]|mm|MM)))"
+    value_re_for_param_section = r"(?P<value>.*?)(?:(?<!( [0-2][0-3]| hh| HH)):(?!([0-5][0-9]|mm|MM)))"
     name_with_dots_re = r"\.?(?P<name>[^.].*[.])\."
     no_desc_re = ""
 

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -737,6 +737,8 @@ def read_header_line(line, pattern=None, section_name=None):
 
     # Alternate regular expressions for special cases
     value_without_colon_delimiter_re = r"(?P<value>[^:]*)"
+    value_re_for_param_section =
+        r"(?P<value>.*?)(?:(?<!( [0-2][0-3]| hh| HH)):(?!([0-5][0-9]|mm|MM)))"
     name_with_dots_re = r"\.?(?P<name>[^.].*[.])\."
     no_desc_re = ""
 
@@ -762,6 +764,8 @@ def read_header_line(line, pattern=None, section_name=None):
                 # description string.
                 if double_dot < desc_colon:
                     name_re = name_with_dots_re
+            if section_name == 'Parameter':
+                value_re = value_re_for_param_section
 
     # Build full regex pattern
     pattern = (

--- a/tests/examples/colon_pick_end.las
+++ b/tests/examples/colon_pick_end.las
@@ -1,0 +1,49 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+MUD .               GEL CHEM:   MUD TYPE
+BHT .DEGC            35.5000:   BOTTOM HOLE TEMPERATURE
+BS  .MM             200.0000:   BIT SIZE
+FD  .K/M3          1000.0000:   FLUID DENSITY
+MATR.                   SAND:   NEUTRON MATRIX
+MDEN.              2710.0000:   LOGGING MATRIX DENSITY
+RMF .OHMM             0.2160:   MUD FILTRATE RESISTIVITY
+DFD .K/M3          1525.0000:   DRILL FLUID DENSITY
+TCS .hh:mm 21:30 23-JAN-2001:   Time Circ. Stopped
+TIML.hh:mm 23:15 23-JAN-2001:   Time Logger At Bottom:
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/examples/colon_pick_start.las
+++ b/tests/examples/colon_pick_start.las
@@ -1,0 +1,49 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+TCS .hh:mm 21:30 23-JAN-2001:   Time Circ. Stopped
+TIML.hh:mm 23:15 23-JAN-2001:   Time Logger: At Bottom
+MUD .               GEL CHEM:   MUD TYPE
+BHT .DEGC            35.5000:   BOTTOM HOLE TEMPERATURE
+BS  .MM             200.0000:   BIT SIZE
+FD  .K/M3          1000.0000:   FLUID DENSITY
+MATR.                   SAND:   NEUTRON MATRIX
+MDEN.              2710.0000:   LOGGING MATRIX DENSITY
+RMF .OHMM             0.2160:   MUD FILTRATE RESISTIVITY
+DFD .K/M3          1525.0000:   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -402,3 +402,14 @@ def test_dot_delimiter_issue_264():
         "",
     ]
 
+def test_issue_201_non_delimiter_colon_start():
+    las = lasio.read(egfn("colon_pick_start.las"))
+    assert las.params["TCS"].unit == "hh:mm"
+    assert las.params["TCS"].value == "21:30 23-JAN-2001"
+    assert las.params["TCS"].descr == "Time Circ. Stopped"
+
+def test_issue_201_non_delimiter_colon_end():
+    las = lasio.read(egfn("colon_pick_end.las"))
+    assert las.params["TCS"].unit == "hh:mm"
+    assert las.params["TCS"].value == "21:30 23-JAN-2001"
+    assert las.params["TCS"].descr == "Time Circ. Stopped"

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -406,12 +406,12 @@ def test_issue_201_non_delimiter_colon_start():
     las = lasio.read(egfn("colon_pick_start.las"))
     assert las.params["TCS"].descr == "Time Circ. Stopped"
     assert las.params["TIML"].unit == "hh:mm"
-    assert las.params["TIML"].value == "21:30 23-JAN-2001"
+    assert las.params["TIML"].value == "23:15 23-JAN-2001"
     # assert las.params["TIML"].descr == "Time Logger: At Bottom"
 
 def test_issue_201_non_delimiter_colon_end():
     las = lasio.read(egfn("colon_pick_end.las"))
     assert las.params["TCS"].descr == "Time Circ. Stopped"
     assert las.params["TIML"].unit == "hh:mm"
-    assert las.params["TIML"].value == "21:30 23-JAN-2001"
+    assert las.params["TIML"].value == "23:15 23-JAN-2001"
     # assert las.params["TIML"].descr == "Time Logger At Bottom:"

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -404,12 +404,14 @@ def test_dot_delimiter_issue_264():
 
 def test_issue_201_non_delimiter_colon_start():
     las = lasio.read(egfn("colon_pick_start.las"))
-    assert las.params["TCS"].unit == "hh:mm"
-    assert las.params["TCS"].value == "21:30 23-JAN-2001"
     assert las.params["TCS"].descr == "Time Circ. Stopped"
+    assert las.params["TIML"].unit == "hh:mm"
+    assert las.params["TIML"].value == "21:30 23-JAN-2001"
+    # assert las.params["TIML"].descr == "Time Logger: At Bottom"
 
 def test_issue_201_non_delimiter_colon_end():
     las = lasio.read(egfn("colon_pick_end.las"))
-    assert las.params["TCS"].unit == "hh:mm"
-    assert las.params["TCS"].value == "21:30 23-JAN-2001"
     assert las.params["TCS"].descr == "Time Circ. Stopped"
+    assert las.params["TIML"].unit == "hh:mm"
+    assert las.params["TIML"].value == "21:30 23-JAN-2001"
+    # assert las.params["TIML"].descr == "Time Logger At Bottom:"

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -407,11 +407,11 @@ def test_issue_201_non_delimiter_colon_start():
     assert las.params["TCS"].descr == "Time Circ. Stopped"
     assert las.params["TIML"].unit == "hh:mm"
     assert las.params["TIML"].value == "23:15 23-JAN-2001"
-    # assert las.params["TIML"].descr == "Time Logger: At Bottom"
+    assert las.params["TIML"].descr == "Time Logger: At Bottom"
 
 def test_issue_201_non_delimiter_colon_end():
     las = lasio.read(egfn("colon_pick_end.las"))
     assert las.params["TCS"].descr == "Time Circ. Stopped"
     assert las.params["TIML"].unit == "hh:mm"
     assert las.params["TIML"].value == "23:15 23-JAN-2001"
-    # assert las.params["TIML"].descr == "Time Logger At Bottom:"
+    assert las.params["TIML"].descr == "Time Logger At Bottom:"

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -1,0 +1,13 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from pprint import pprint
+
+from lasio.reader import read_header_line
+
+def test_time_str_and_colon_in_desc():
+    line = 'TIML.hh:mm 23:15 23-JAN-2001:   Time Logger: At Bottom'
+    result = read_header_line(line, section_name='Parameter')
+    # print('\n')
+    # pprint(result)
+    assert( result['value'] == '23:15 23-JAN-2001' )
+    assert( result['descr'] == 'Time Logger: At Bottom' )


### PR DESCRIPTION
This change includes the change/fix for #201  and the test files to verify the change.

It incorporates test .las file examples from 
https://github.com/kinverarity1/lasio/tree/issue201-multiple-colons

And code solutions from : 
https://github.com/RomCoch/lasio/commit/71e97fdf32ea8b29c245973a047ccd45a9ce0bb2
and
https://github.com/RomCoch/lasio/commit/156def9008c385b8d3cef7c04facbafbac615496

The test cases can be run with
```
pytest -s -v tests/test_read.py::test_issue_201_non_delimiter_colon_start
pytest -s -v tests/test_read.py::test_issue_201_non_delimiter_colon_end
```

The test suite passed with this change included.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,

DC


