### PR TITLE
Fix some cases of lasio json output

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -897,9 +897,11 @@ class JSONEncoder(json.JSONEncoder):
                 if isinstance(section, basestring):
                     d["metadata"][name] = section
                 else:
-                    d["metadata"][name] = []
-                    for item in section:
-                        d["metadata"][name].append(dict(item))
+                    try:
+                        d["metadata"][name] = section.dictview()
+                    except:
+                        for item in section:
+                            d["metadata"][name].append(dict(item))
             for curve in obj.curves:
                 d["data"][curve.mnemonic] = list(curve.data)
             return d

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -24,3 +24,14 @@ def test_json_encoder_default():
 def test_json_encoder_cls_specify():
     l = read(egfn("sample.las"))
     t = json.dumps(l, cls=las.JSONEncoder)
+
+def test_json_headers():
+    l = read("./tests/examples/2.0/sample_2.0.las")
+    lj = json.dumps(l, cls=las.JSONEncoder)
+    pylj = json.loads(lj)
+    assert(pylj['metadata']['Version']['VERS'] == 2.0)
+    assert(pylj['metadata']['Version']['WRAP'] == 'NO')
+    assert(pylj['metadata']['Well']['STRT'] == 1670)
+    assert(pylj['metadata']['Curves']['DT'] == '60 520 32 00')
+    assert(pylj['metadata']['Parameter']['DFD'] == 1525)
+


### PR DESCRIPTION
This change is related to #107.  it is an iterative improvement over the 
current JSON output. If accepted it may be replaced by subsequent 
improvements to the Lasio Json interface.

This change adds section.dictview() to las.JSONEncoder in order
to include missing data in json output. Note that header-description
data is still missing from the output.

Added json test case for v2.0 headers. Code-Cov reports that the test 
case did not cover the changed code. Currently, I'm not sure how to make
a test case that gets in to test the specific code change. However, the
 inclueded test case does verify the improved json input.  

I wasn't able to verify that sections.dictview() would work with Python2. So
sections.dictview() is wrapped in a 'try' with an 'except' that runs the old code.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,

DC

Here are the steps to reproduce the result in python:

```python
import json
import lasio
from lasio import las
l = lasio.read("./tests/examples/2.0/sample_2.0.las")

# To a file
with open('sample_2.0.json', 'w') as fp:
    json.dump(l, fp, cls=las.JSONEncoder)

# Or to a json string
lasio_json = json.dumps(l, cls=las.JSONEncoder)
```

Here is the resulting sample_2.0.json:

```node
{
    "data": {
        "DEPT": [
            1670.0,
            1669.875,
            1669.75
        ],
        "DT": [
            123.45,
            123.45,
            123.45
        ],
        "ILD": [
            105.6,
            105.6,
            105.6
        ],
        "ILM": [
            110.2,
            110.2,
            110.2
        ],
        "NPHI": [
            0.45,
            0.45,
            0.45
        ],
        "RHOB": [
            2550.0,
            2550.0,
            2550.0
        ],
        "SFLA": [
            123.45,
            123.45,
            123.45
        ],
        "SFLU": [
            123.45,
            123.45,
            123.45
        ]
    },
    "metadata": {
        "Curves": {
            "DEPT": "",
            "DT": "60 520 32 00",
            "ILD": "07 120 46 00",
            "ILM": "07 120 44 00",
            "NPHI": "42 890 00 00",
            "RHOB": "45 350 01 00",
            "SFLA": "07 222 01 00",
            "SFLU": "07 220 04 00"
        },
        "Other": "Note: The logging tools became stuck at 625 metres causing the data\nbetween 625 metres and 615 metres to be invalid.",
        "Parameter": {
            "BHT": 35.5,
            "BS": 200.0,
            "DFD": 1525.0,
            "FD": 1000.0,
            "MATR": "SAND",
            "MDEN": 2710.0,
            "MUD": "GEL CHEM",
            "RMF": 0.216
        },
        "Version": {
            "VERS": 2.0,
            "WRAP": "NO"
        },
        "Well": {
            "COMP": "ANY OIL COMPANY INC.",
            "DATE": "13-DEC-86",
            "FLD": "WILDCAT",
            "LOC": "12-34-12-34W5M",
            "NULL": -999.25,
            "PROV": "ALBERTA",
            "SRVC": "ANY LOGGING COMPANY INC.",
            "STEP": -0.125,
            "STOP": 1660.0,
            "STRT": 1670.0,
            "UWI": "100123401234W500",
            "WELL": "AAAAA_2"
        }
    }
}
```
