### PR TITLE
#304: Add column_fmt kwarg to lasio.writer.write()

### DIFF
--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -45,7 +45,7 @@ def write(
         fmt (str): Python string formatting operator for numeric data to be
             used.
         column_fmt (dict or None): use this to set a different format string
-            for specific columns from the data ndarray. E.g. to use ``'%.4f'``
+            for specific columns from the data ndarray. E.g. to use ``'%.3f'``
             for the depth column and ``'%.2f'`` for all the other columns,
             you would use ``fmt='%.2f', column_fmt={0: '%.3f'}``.
         len_numeric_field (int): width of each numeric field column (must be


### PR DESCRIPTION
Allows the use of different fmt codes for different columns.

(Addressing issue #304).

This code adds the kwarg "column_fmt" to lasio.writer.write(). See the docstring for how to use (irrelevant parts not shown):

```
def write(
    ...,
    fmt="%.5f",
    column_fmt=None,
):
    """Write a LAS files.

    Arguments:

        fmt (str): Python string formatting operator for numeric data to be
            used.
        column_fmt (dict or None): use this to set a different format string
            for specific columns from the data ndarray. E.g. to use ``'%.3f'``
            for the depth column and ``'%.2f'`` for all the other columns,
            you would use ``fmt='%.2f', column_fmt={0: '%.3f'}``.
```

And a code example:

```
>>> lasio.examples.open('sample.las').write(
...     sys.stdout, fmt='%.2f', column_fmt={0: '%.3f'}, wrap=False
... )
<clipped>
~ASCII -----------------------------------------------------
   1670.000     123.45    2550.00       0.45     123.45     123.45     110.20     105.60
   1669.875     123.45    2550.00       0.45     123.45     123.45     110.20     105.60
   1669.750     123.45    2550.00       0.45     123.45     123.45     110.20     105.60

>>> lasio.examples.open('sample.las').write(
...     sys.stdout, fmt='%.2f', column_fmt={0: '%.3f'}, wrap=True
... )
<clipped>
~ASCII -----------------------------------------------------
   1670.000     123.45    2550.00       0.45     123.45     123.45     110.20
105.60
   1669.875     123.45    2550.00       0.45     123.45     123.45     110.20
105.60
   1669.750     123.45    2550.00       0.45     123.45     123.45     110.20
105.60
```