### PR TITLE
Issue-310: Implement draft solution to fix LASFile.metadata

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -589,32 +589,6 @@ class LASFile(object):
         self.sections["Other"] = section
 
     @property
-    def metadata(self):
-        """All header information joined together.
-
-        Returns:
-            :class:`lasio.SectionItems` object.
-
-        """
-        s = SectionItems()
-        for section_name, section in self.sections.items():
-            if not hasattr(section, 'assign_duplicate_suffixes'):
-                logger.warning( """
-WARNING: Section skipped: It doesn't have an assign_duplicate_suffixes method.
-    SectionName: %s
-    SectionContent:
-        %s\n""" % (section_name, section)
-                )
-                continue
-            for item in section:
-                s.append(item)
-        return s
-
-    @metadata.setter
-    def metadata(self, value):
-        raise NotImplementedError("Set values in the section directly")
-
-    @property
     def header(self):
         """All header information
 

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -597,7 +597,15 @@ class LASFile(object):
 
         """
         s = SectionItems()
-        for section in self.sections:
+        for section_name, section in self.sections.items():
+            if not hasattr(section, 'assign_duplicate_suffixes'):
+                logger.warning( """
+WARNING: Section skipped: It doesn't have an assign_duplicate_suffixes method.
+    SectionName: %s
+    SectionContent:
+        %s\n""" % (section_name, section)
+                )
+                continue
             for item in section:
                 s.append(item)
         return s


### PR DESCRIPTION
This branch explores possible solutions to issue #310 

This commit explores two changes.
1. Cycle through self.sections.items() instead of self.sections so we can access both the section_names and SectionItem objects.

2. Check that each SectionItem object has an
assign_duplicate_suffixes() method. If the object doesn't have this method, then log a warning and continue to on to the next section.
This will occur on a SectionItem that includes a header item which isn't parsed into a HeaderItem object (mnemonic, unit, value, desc).  An example of this an the '~Other' section that parsed into a str object and only contains a text comment (tests/example/sample.las).

Here is the SectionItem.append() code that a non-HeaderItem section will fail on if it doesn't have 
```python
    SectionItem.append(self, newitem):
        '''Append a new HeaderItem to the object.'''
        super(SectionItems, self).append(newitem)
        self.assign_duplicate_suffixes(newitem.useful_mnemonic)
```


These changes enable LASFile.metadata to display the metadata for all header information that is in the HeaderItem object format.  Should additional changes be made to enable handling string object metadata/headers or other non-standard header information?  

Thanks,
DC