### PR TITLE
WIP: Issue-312: Add a reasonable non-dist lasio.__version__ option

### DIFF
--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -1,9 +1,17 @@
+import subprocess
 from pkg_resources import get_distribution, DistributionNotFound
 
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
-    # package is not installed
+    __version__ = "A Dev version: probably in a git repo."
+    tmpbytes = subprocess.check_output(
+        ["git", "log", "-1", "--pretty=tformat:Commit %h"]
+    ).strip()
+
+    tmpstr = "".join( chr(x) for x in tmpbytes)
+    if tmpstr.startswith("Commit"):
+       __version__ = "Dev version: {}".format(tmpstr)
     pass
 
 import os

--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -1,29 +1,12 @@
-import subprocess, re
-from pkg_resources import get_distribution, DistributionNotFound
-
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # default version
-    __version__ = "0.0.0.unknown.version"
-
-    semver_regex = re.compile('^\d+\.\d+\.\d+')
-
-    # python setup.py --version
-    tmpstr = subprocess.check_output(
-        ["python", "setup.py", "--version"],
-        encoding='utf-8'
-    ).strip()
-
-    if semver_regex.match(tmpstr):
-       __version__ = tmpstr
-    pass
 
 import os
 
+from .las_version import get_version
 from .las import LASFile, JSONEncoder
 from .las_items import CurveItem, HeaderItem, SectionItems
 from .reader import open_file
+
+__version__ = get_version()
 
 try:
     import openpyxl

--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -1,12 +1,12 @@
 
 import os
 
-from .las_version import get_version
+from .las_version import version
 from .las import LASFile, JSONEncoder
 from .las_items import CurveItem, HeaderItem, SectionItems
 from .reader import open_file
 
-__version__ = get_version()
+__version__ = version()
 
 try:
     import openpyxl

--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -1,17 +1,22 @@
-import subprocess
+import subprocess, re
 from pkg_resources import get_distribution, DistributionNotFound
 
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
-    __version__ = "A Dev version: probably in a git repo."
-    tmpbytes = subprocess.check_output(
-        ["git", "log", "-1", "--pretty=tformat:Commit %h"]
+    # default version
+    __version__ = "0.0.0.unknown.version"
+
+    semver_regex = re.compile('^\d+\.\d+\.\d+')
+
+    # python setup.py --version
+    tmpstr = subprocess.check_output(
+        ["python", "setup.py", "--version"],
+        encoding='utf-8'
     ).strip()
 
-    tmpstr = "".join( chr(x) for x in tmpbytes)
-    if tmpstr.startswith("Commit"):
-       __version__ = "Dev version: {}".format(tmpstr)
+    if semver_regex.match(tmpstr):
+       __version__ = tmpstr
     pass
 
 import os

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -1,0 +1,56 @@
+import subprocess, re
+from pkg_resources import get_distribution, DistributionNotFound
+from datetime import datetime
+
+ver_date = datetime.now().strftime("d%Y%M%d")
+
+def get_version():
+    las_version = ''
+
+    # Test for distribution version
+    try:
+        las_version = get_distribution(__name__).version
+    except DistributionNotFound:
+        pass
+
+    # Test for version control system version
+    if not las_version.strip():
+        las_version = _get_vcs_version()
+
+
+    # Else set a sensible default version
+    if not las_version.strip():
+        las_version = (
+            "0.25.0.dev0+unknown-post-dist-version.{}".format(ver_date)
+        )
+
+    return las_version
+
+def _get_vcs_version():
+    semver_regex = re.compile('^v\d+\.\d+\.\d+')
+    split_regex = re.compile('-')
+    empty_las_version = ''
+    tmpstr = ''
+
+    try:    
+        # https://git-scm.com/docs/git-describe
+        # git describe --tags --match 'v*'
+        tmpstr = subprocess.check_output(
+            # ["python", "setup.py", "--version"],
+            ["git", "describe", "--tags", "--match", "v*"],
+            encoding='utf-8'
+        ).strip()
+
+    except Exception as e:
+        print("Exception: {}\n".format(e))
+        pass
+
+    if semver_regex.match(tmpstr):
+        tmpstr = tmpstr[1:]
+        (rel_ver, commits_since_rel_ver, current_commit) = split_regex.split(tmpstr)
+        empty_las_version = "{}.dev{}+{}.{}".format(
+            rel_ver, commits_since_rel_ver, current_commit, ver_date
+        )
+
+    return empty_las_version
+

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 ver_date = datetime.now().strftime("d%Y%m%d")
 
-def get_version():
+def version():
     las_version = ''
 
     # Test for distribution version

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -48,7 +48,7 @@ def _get_vcs_version():
     try:
         tmpstr = "".join( chr(x) for x in tmpbytes)
     except TypeError as e:
-        print("Error: {}\n".format(e.msg))
+        print("Error: {}\n".format(e))
 
     if semver_regex.match(tmpstr):
         tmpstr = tmpstr[1:]

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -30,6 +30,7 @@ def _get_vcs_version():
     split_regex = re.compile('-')
     local_las_version = ''
     tmpstr = ''
+    tmpbytes = b''
 
     try:    
         # https://git-scm.com/docs/git-describe
@@ -40,10 +41,14 @@ def _get_vcs_version():
             stderr=subprocess.STDOUT,
         ).strip()
 
-        # Convert byte string to text string
-        tmpstr = "".join( chr(x) for x in tmpbytes)
     except subprocess.CalledProcessError:
         pass
+
+    # Convert byte string to text string
+    try:
+        tmpstr = "".join( chr(x) for x in tmpbytes)
+    except TypeError as e:
+        print("Error: {}\n".format(e.msg))
 
     if semver_regex.match(tmpstr):
         tmpstr = tmpstr[1:]

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -34,12 +34,14 @@ def _get_vcs_version():
     try:    
         # https://git-scm.com/docs/git-describe
         # git describe --tags --match 'v*'
-        tmpstr = subprocess.check_output(
+        tmpbytes = subprocess.check_output(
             # ["python", "setup.py", "--version"],
             ["git", "describe", "--tags", "--match", "v*"],
             stderr=subprocess.STDOUT,
-            text=True
         ).strip()
+
+        # Convert byte string to text string
+        tmpstr = "".join( chr(x) for x in tmpbytes)
     except subprocess.CalledProcessError:
         pass
 

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -2,7 +2,7 @@ import subprocess, re
 from pkg_resources import get_distribution, DistributionNotFound
 from datetime import datetime
 
-ver_date = datetime.now().strftime("d%Y%M%d")
+ver_date = datetime.now().strftime("d%Y%m%d")
 
 def get_version():
     las_version = ''
@@ -17,7 +17,6 @@ def get_version():
     if not las_version.strip():
         las_version = _get_vcs_version()
 
-
     # Else set a sensible default version
     if not las_version.strip():
         las_version = (
@@ -29,7 +28,7 @@ def get_version():
 def _get_vcs_version():
     semver_regex = re.compile('^v\d+\.\d+\.\d+')
     split_regex = re.compile('-')
-    empty_las_version = ''
+    local_las_version = ''
     tmpstr = ''
 
     try:    
@@ -38,19 +37,18 @@ def _get_vcs_version():
         tmpstr = subprocess.check_output(
             # ["python", "setup.py", "--version"],
             ["git", "describe", "--tags", "--match", "v*"],
+            stderr=subprocess.STDOUT,
             encoding='utf-8'
         ).strip()
-
-    except Exception as e:
-        print("Exception: {}\n".format(e))
+    except subprocess.CalledProcessError:
         pass
 
     if semver_regex.match(tmpstr):
         tmpstr = tmpstr[1:]
         (rel_ver, commits_since_rel_ver, current_commit) = split_regex.split(tmpstr)
-        empty_las_version = "{}.dev{}+{}.{}".format(
+        local_las_version = "{}.dev{}+{}.{}".format(
             rel_ver, commits_since_rel_ver, current_commit, ver_date
         )
 
-    return empty_las_version
+    return local_las_version
 

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -38,7 +38,7 @@ def _get_vcs_version():
             # ["python", "setup.py", "--version"],
             ["git", "describe", "--tags", "--match", "v*"],
             stderr=subprocess.STDOUT,
-            encoding='utf-8'
+            text=True
         ).strip()
     except subprocess.CalledProcessError:
         pass

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,10 @@ setup(
     keywords="science geophysics io",
     packages=("lasio",),
     install_requires=("numpy",),
-    extras_require={"all": ("pandas", "cchardet", "openpyxl", "argparse")},
+    extras_require={
+        "all": ("pandas", "cchardet", "openpyxl", "argparse"),
+        "test": ("pytest>=3.6", "pytest-cov", "coverage", "codecov", "pathlib")
+    },
     tests_require=("pytest>=3.6", "pytest-cov", "coverage", "codecov", "pathlib"),
     entry_points={
         "console_scripts": (

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author="Kent Inverarity",
     author_email="kinverarity@hotmail.com",
     license="MIT",
-    classifiers=(
+    classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",
         "Intended Audience :: Customer Service",
@@ -38,7 +38,7 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: System :: Filesystems",
         "Topic :: Scientific/Engineering :: Information Analysis",
-    ),
+    ],
     keywords="science geophysics io",
     packages=("lasio",),
     install_requires=("numpy",),


### PR DESCRIPTION
@kinverarity1,

This is a proposed solution for #312 "Test Failure: test_api.py::test_version failing".  

Its solution is to set a sensible version string when lasio is installed from GitHub and doesn't have a distribution tag-based version string.   It is in 'draft'/'work-in-progress' mode because I still need to update the version test for this case.

Let me know this will be a satisfactory solution or if there are changes/improvements I can make  .

Thank you,
DC