### PR TITLE
Update setup.py for current lasio (post 0.25.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@
 from setuptools import setup
 import os
 
+EXTRA_REQS = ("pandas", "cchardet", "openpyxl", "argparse")
+TEST_REQS = (
+    "pytest>=3.6", "pytest-cov", "coverage", "codecov", "pathlib"
+)
 
 setup(
     name="lasio",
@@ -15,7 +19,7 @@ setup(
     author="Kent Inverarity",
     author_email="kinverarity@hotmail.com",
     license="MIT",
-    classifiers=(
+    classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",
         "Intended Audience :: Customer Service",
@@ -27,7 +31,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",
@@ -35,15 +38,20 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering",
         "Topic :: System :: Filesystems",
         "Topic :: Scientific/Engineering :: Information Analysis",
-    ),
+    ],
     keywords="science geophysics io",
     packages=("lasio",),
     install_requires=("numpy",),
-    extras_require={"all": ("pandas", "cchardet", "openpyxl", "argparse")},
-    tests_require=("pytest>=3.6", "pytest-cov", "coverage", "codecov", "pathlib"),
+    extras_require={
+        "all": EXTRA_REQS,
+        "las_test_reqs": ( EXTRA_REQS, TEST_REQS)
+    },
+    tests_require= (TEST_REQS),
     entry_points={
         "console_scripts": (
             "las2excel = lasio.excel:main",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     install_requires=("numpy",),
     extras_require={
         "all": EXTRA_REQS,
-        "las_test_reqs": ( EXTRA_REQS, TEST_REQS)
+        "test": ( EXTRA_REQS, TEST_REQS)
     },
     tests_require= (TEST_REQS),
     entry_points={


### PR DESCRIPTION
It is probably best to cut a patch release since setuptools_scm integrated in master before considering this pull request.  

This is a maintenance update of setup.py for the post-0.25.0 lasio.

- Fix warning: 'classifiers should be list not tuple

- Update 'Programming Language' classifers to the python versions being
  tested in travis-ci on release: remove: 2.6, add: 3.7 and 3.8

- Add setup.extras_requires['las_test_reqs']. Since the requirements
  files are removed and setup.test_requires doesn't directly install the
  required test packages 'las_test_reqs' enables a developer to add the
  needed test packages (and extra packages) to a dev environment
  needed to pass the full test suite. If a lasio package is created with
  this setup.py then 'pip install lasio[las_test_reqs]' will install the
  the extra and test packages.

I've tested this in the following ways with python 3.7 in a fresh virtualenv:
1. installed lasio 0.25.0 then tried 'pip install lasio[las_test_reqs]'
   This behaved as expected.  Because release 0.25.0 wasn't created
   with this setup.py version 0.25.0 didn't have a extras_require.las_test_reqs
   so it didn't install anything additional.

2. created a local lasio wheel file with bdist_wheel and installed it and then 
   ran 'pip install lasio[las_test_reqs]'. This installed all the extra packages.
   Then ran 'pytest'.  The test suite ran and all tests passed.  

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC