### PR TITLE
Add kwargs for skipping comment lines in the data section

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -92,7 +92,7 @@ class LASFile(object):
         ignore_header_errors=False,
         mnemonic_case="upper",
         index_unit=None,
-        remove_line_filter="#"
+        remove_line_filter="#",
         **kwargs
     ):
         """Read a LAS file.

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -92,6 +92,7 @@ class LASFile(object):
         ignore_header_errors=False,
         mnemonic_case="upper",
         index_unit=None,
+        remove_line_filter="#"
         **kwargs
     ):
         """Read a LAS file.
@@ -111,6 +112,12 @@ class LASFile(object):
                                  'upper': convert all HeaderItem mnemonics to uppercase
                                  'lower': convert all HeaderItem mnemonics to lowercase
             index_unit (str): Optionally force-set the index curve's unit to "m" or "ft"
+            remove_line_filter (str, func): string or function for removing/ignoring lines
+                in the data section e.g. a function which accepts a string (a line)
+                and returns either True (do not parse the line) or False (parse the line).
+                If this is a string it will be converted to a function which rejects all
+                lines starting with that value e.g. ``"#"`` will be converted to
+                ``lambda line: line.strip().startswith("#")``.
 
         See :func:`lasio.reader.open_with_codecs` for additional keyword
         arguments which help to manage issues relate to character encodings.
@@ -125,7 +132,7 @@ class LASFile(object):
 
         try:
             self.raw_sections = reader.read_file_contents(
-                file_obj, regexp_subs, value_null_subs, ignore_data=ignore_data
+                file_obj, regexp_subs, value_null_subs, ignore_data=ignore_data, remove_line_filter="#"
             )
         finally:
             if hasattr(file_obj, "close"):

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -311,7 +311,8 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
     sect_title_line = None
     section_exists = False
     if isinstance(remove_line_filter, str):
-        remove_line_filter = lambda line: line.strip().startswith(remove_line_filter)
+        value = str(remove_line_filter)
+        remove_line_filter = lambda line: line.strip().startswith(value)
 
     for i, line in enumerate(file_obj):
         line = line.strip()

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -414,14 +414,15 @@ def read_data_section_iterative(file_obj, regexp_subs, value_null_subs, remove_l
         for line in f:
             if remove_line_filter is not None:
                 if remove_line_filter(line):
-                    pass
-            for pattern, sub_str in regexp_subs:
-                line = re.sub(pattern, sub_str, line)
-            for item in line.split():
-                try:
-                    yield np.float64(item)
-                except ValueError:
-                    yield item
+                    continue
+                else:
+                    for pattern, sub_str in regexp_subs:
+                        line = re.sub(pattern, sub_str, line)
+                    for item in line.split():
+                        try:
+                            yield np.float64(item)
+                        except ValueError:
+                            yield item
 
     array = np.array([i for i in items(file_obj)])
     for value in value_null_subs:

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -265,7 +265,7 @@ def get_encoding(auto, raw):
     return result["encoding"]
 
 
-def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False):
+def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False, remove_line_filter=None):
     """Read file contents into memory.
 
     Arguments:
@@ -275,6 +275,8 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
         null_subs (bool): True will substitute ``numpy.nan`` for invalid values
         ignore_data (bool): if True, do not read in the numerical data in the
             ~ASCII section
+        remove_line_filter (func): a function which accepts a string (a line)
+            and returns either True (do not parse the line) or False (parse the line).
 
     Returns:
         OrderedDict
@@ -323,7 +325,7 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
             if not ignore_data:
                 try:
                     data = read_data_section_iterative(
-                        file_obj, regexp_subs, value_null_subs
+                        file_obj, regexp_subs, value_null_subs, remove_line_filter=remove_line_filter
                     )
                 except KeyboardInterrupt:
                     raise
@@ -381,7 +383,7 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
     return sections
 
 
-def read_data_section_iterative(file_obj, regexp_subs, value_null_subs):
+def read_data_section_iterative(file_obj, regexp_subs, value_null_subs, remove_line_filter=None):
     """Read data section into memory.
 
     Arguments:
@@ -393,6 +395,8 @@ def read_data_section_iterative(file_obj, regexp_subs, value_null_subs):
             data section. See defaults.py READ_SUBS and NULL_SUBS for examples.
         value_null_subs (list): list of numerical values to be replaced by
             numpy.nan values.
+        remove_line_filter (func): a function which accepts a string (a line)
+            and returns either True (do not parse the line) or False (parse the line).
 
     Returns:
         A 1-D numpy ndarray.
@@ -401,6 +405,9 @@ def read_data_section_iterative(file_obj, regexp_subs, value_null_subs):
 
     def items(f):
         for line in f:
+            if remove_line_filter is not None:
+                if remove_line_filter(line):
+                    pass
             for pattern, sub_str in regexp_subs:
                 line = re.sub(pattern, sub_str, line)
             for item in line.split():

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -275,8 +275,12 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
         null_subs (bool): True will substitute ``numpy.nan`` for invalid values
         ignore_data (bool): if True, do not read in the numerical data in the
             ~ASCII section
-        remove_line_filter (func): a function which accepts a string (a line)
+        remove_line_filter (str, func): string or function for removing/ignoring lines
+            in the data section e.g. a function which accepts a string (a line)
             and returns either True (do not parse the line) or False (parse the line).
+            If this is a string it will be converted to a function which rejects all
+            lines starting with that value e.g. ``"#"`` will be converted to
+            ``lambda line: line.strip().startswith("#")``.
 
     Returns:
         OrderedDict
@@ -306,6 +310,8 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
     sect_line_nos = []
     sect_title_line = None
     section_exists = False
+    if isinstance(remove_line_filter, str):
+        remove_line_filter = lambda line: line.strip().startswith(remove_line_filter)
 
     for i, line in enumerate(file_obj):
         line = line.strip()

--- a/tests/examples/skip_data_section_comments.las
+++ b/tests/examples/skip_data_section_comments.las
@@ -1,0 +1,32 @@
+~VERSION INFORMATION
+ VERS.                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
+ WRAP.                  NO:   ONE LINE PER DEPTH STEP
+~WELL INFORMATION BLOCK
+ STRT.M        1670.000000:
+ STOP.M        1660.000000:
+ STEP.M            -0.1250:
+ NULL.           -999.2500:
+ COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ WELL.                WELL:   ANY ET AL OIL WELL #12
+ FLD .               FIELD:   EDAM
+ LOC .            LOCATION:   A9-16-49-20W3M
+ PROV.            PROVINCE:   SASKATCHEWAN
+ SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY LTD.
+ DATE.            LOG DATE:   25-DEC-1988
+ UWI .      UNIQUE WELL ID:   100091604920W300
+~CURVE INFORMATION
+ ETIM.M                      :  1  DEPTH
+ BSG1  .US/M     		     :  2  SONIC TRANSIT TIME
+ BQP1.K/M3                   :  3  BULK DENSITY
+ POMS.V/V                    :  4   NEUTRON POROSITY
+ POPV.OHMM                   :  5  RXO RESISTIVITY
+ HMS1.OHMM                   :  6  SHALLOW RESISTIVITY
+~PARAMETER INFORMATION
+~Other
+~ASCII Test Data
+#	ETIM	BSG1	BQP1	POMS	POPV	HMS1
+#--------------------------------------------------------
+      0.300	  2355.765	  2343.880	     0.000	     0.000	     0.000	
+      0.400	  2355.765	  2343.880	     0.000	     0.000	     0.000	
+      0.500	  2355.765	  2343.880	     0.000	     0.000	     0.000	
+      0.600	  2355.765	  2343.880	     0.000	     0.000	     0.000	

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -415,3 +415,7 @@ def test_issue_201_non_delimiter_colon_end():
     assert las.params["TIML"].unit == "hh:mm"
     assert las.params["TIML"].value == "23:15 23-JAN-2001"
     assert las.params["TIML"].descr == "Time Logger At Bottom:"
+
+def test_skip_comments_in_data_section():
+    l = lasio.read(egfn("skip_data_section_comments.las"))
+    assert (l.curves[0].data == [0.3, 0.4, 0.5, 0.6]).all()


### PR DESCRIPTION
Add the remove_line_filter=lambda line: True|False kwarg to read_data_section_iterative() - intended to fix #319 eventually.

This is a work in progress.