### PR TITLE
Align json.dumps and LASFile.to_json()

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -850,7 +850,7 @@ class LASFile(object):
         """Return object contents as a JSON string."""
         return self.to_json()
 
-    def to_json(self):
+    def to_json_old(self):
         obj = OrderedDict()
         for name, section in self.sections.items():
             try:
@@ -858,6 +858,9 @@ class LASFile(object):
             except AttributeError:
                 obj[name] = json.dumps(section)
         return json.dumps(obj)
+
+    def to_json(self):
+        return json.dumps(self, cls=JSONEncoder)
 
     @json.setter
     def json(self, value):


### PR DESCRIPTION
This PR aligns `las.to_json()` (which is broken and out of date) so that it runs the same code path as `json.dumps(las, cls=lasio.JSONEncoder)`.

The old function is still available as `las.to_json_old()` just in case someone was using it (seems unlikely)