### PR TITLE
Add lasversionconvert script

### DIFF
--- a/lasio/convert_version.py
+++ b/lasio/convert_version.py
@@ -1,0 +1,43 @@
+import argparse
+import os
+import sys
+
+import lasio
+
+
+def convert_version():
+    args = get_convert_version_parser().parse_args(sys.argv[1:])
+
+    assert os.path.isfile(args.input)
+
+    las = lasio.read(args.input, ignore_header_errors=args.ignore_header_errors)
+
+    if os.path.isfile(args.output) and not args.overwrite:
+        raise OSError("Output file already exists")
+
+    with open(args.output, "w") as f:
+        las.write(f, version=float(args.to))
+
+
+def get_convert_version_parser():
+    parser = argparse.ArgumentParser(
+        "Convert LAS file version",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("-t", "--to", default=2, help="Version to convert to")
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        default=False,
+        help="Overwrite output file if it already exists",
+    )
+    parser.add_argument(
+        "-i",
+        "--ignore-header-errors",
+        action="store_true",
+        help="Ignore header section errors.",
+        default=False,
+    )
+    parser.add_argument("input")
+    parser.add_argument("output")
+    return parser

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,7 @@ from setuptools import setup
 import os
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl", "argparse")
-TEST_REQS = (
-    "pytest>=3.6", "pytest-cov", "coverage", "codecov", "pathlib"
-)
+TEST_REQS = ("pytest>=3.6", "pytest-cov", "coverage", "codecov", "pathlib")
 
 setup(
     name="lasio",
@@ -47,15 +45,13 @@ setup(
     keywords="science geophysics io",
     packages=("lasio",),
     install_requires=("numpy",),
-    extras_require={
-        "all": EXTRA_REQS,
-        "test": ( EXTRA_REQS, TEST_REQS)
-    },
-    tests_require= (TEST_REQS),
+    extras_require={"all": EXTRA_REQS, "test": (EXTRA_REQS, TEST_REQS)},
+    tests_require=(TEST_REQS),
     entry_points={
         "console_scripts": (
             "las2excel = lasio.excel:main",
             "las2excelbulk = lasio.excel:main_bulk",
+            "lasversionconvert = lasio.convert_version:convert_version",
             "lasio = lasio:version",
         )
     },


### PR DESCRIPTION
This PR fixes #31 by implementing a command line script `lasversionconvert`:

```
C:\>lasversionconvert --help
usage: Convert LAS file version [-h] [-t TO] [--overwrite] [-i] input output

positional arguments:
  input
  output

optional arguments:
  -h, --help            show this help message and exit
  -t TO, --to TO        Version to convert to (default: 2)
  --overwrite           Overwrite output file if it already exists (default:
                        False)
  -i, --ignore-header-errors
                        Ignore header section errors. (default: False)
```


