### PR TITLE
Add cyrillic metres variant and improve index unit autodetection

### DIFF
--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -2,121 +2,162 @@ import re
 
 import numpy as np
 
-from .las_items import (
-    HeaderItem, SectionItems, OrderedDict
-)
+from .las_items import HeaderItem, SectionItems, OrderedDict
 
 
 def get_default_items():
     return {
-        'Version': SectionItems([
-            HeaderItem('VERS', '', 2.0, 'CWLS log ASCII Standard -VERSION 2.0'),
-            HeaderItem('WRAP', '', 'NO', 'One line per depth step'),
-            HeaderItem('DLM', '', 'SPACE', 'Column Data Section Delimiter'),
-        ]),
-        'Well': SectionItems([
-            HeaderItem('STRT', 'm', np.nan, 'START DEPTH'),
-            HeaderItem('STOP', 'm', np.nan, 'STOP DEPTH'),
-            HeaderItem('STEP', 'm', np.nan, 'STEP'),
-            HeaderItem('NULL', '', -9999.25, 'NULL VALUE'),
-            HeaderItem('COMP', '', '', 'COMPANY'),
-            HeaderItem('WELL', '', '', 'WELL'),
-            HeaderItem('FLD', '', '', 'FIELD'),
-            HeaderItem('LOC', '', '', 'LOCATION'),
-            HeaderItem('PROV', '', '', 'PROVINCE'),
-            HeaderItem('CNTY', '', '', 'COUNTY'),
-            HeaderItem('STAT', '', '', 'STATE'),
-            HeaderItem('CTRY', '', '', 'COUNTRY'),
-            HeaderItem('SRVC', '', '', 'SERVICE COMPANY'),
-            HeaderItem('DATE', '', '', 'DATE'),
-            HeaderItem('UWI', '', '', 'UNIQUE WELL ID'),
-            HeaderItem('API', '', '', 'API NUMBER')
-        ]),
-        'Curves': SectionItems([]),
-        'Parameter': SectionItems([]),
-        'Other': '',
-        'Data': np.zeros(shape=(0, 1)),
+        "Version": SectionItems(
+            [
+                HeaderItem("VERS", "", 2.0, "CWLS log ASCII Standard -VERSION 2.0"),
+                HeaderItem("WRAP", "", "NO", "One line per depth step"),
+                HeaderItem("DLM", "", "SPACE", "Column Data Section Delimiter"),
+            ]
+        ),
+        "Well": SectionItems(
+            [
+                HeaderItem("STRT", "m", np.nan, "START DEPTH"),
+                HeaderItem("STOP", "m", np.nan, "STOP DEPTH"),
+                HeaderItem("STEP", "m", np.nan, "STEP"),
+                HeaderItem("NULL", "", -9999.25, "NULL VALUE"),
+                HeaderItem("COMP", "", "", "COMPANY"),
+                HeaderItem("WELL", "", "", "WELL"),
+                HeaderItem("FLD", "", "", "FIELD"),
+                HeaderItem("LOC", "", "", "LOCATION"),
+                HeaderItem("PROV", "", "", "PROVINCE"),
+                HeaderItem("CNTY", "", "", "COUNTY"),
+                HeaderItem("STAT", "", "", "STATE"),
+                HeaderItem("CTRY", "", "", "COUNTRY"),
+                HeaderItem("SRVC", "", "", "SERVICE COMPANY"),
+                HeaderItem("DATE", "", "", "DATE"),
+                HeaderItem("UWI", "", "", "UNIQUE WELL ID"),
+                HeaderItem("API", "", "", "API NUMBER"),
+            ]
+        ),
+        "Curves": SectionItems([]),
+        "Parameter": SectionItems([]),
+        "Other": "",
+        "Data": np.zeros(shape=(0, 1)),
     }
 
 
 ORDER_DEFINITIONS = {
-    1.2: OrderedDict([
-        ('Version', ['value:descr']),
-        ('Well', [
-            'descr:value',
-            ('value:descr', ['STRT', 'STOP', 'STEP', 'NULL'])]),
-        ('Curves', ['value:descr']),
-        ('Parameter', ['value:descr']),
-    ]),
-    2.0: OrderedDict([
-        ('Version', ['value:descr']),
-        ('Well', ['value:descr']),
-        ('Curves', ['value:descr']),
-        ('Parameter', ['value:descr'])
-    ])}
+    1.2: OrderedDict(
+        [
+            ("Version", ["value:descr"]),
+            (
+                "Well",
+                ["descr:value", ("value:descr", ["STRT", "STOP", "STEP", "NULL"])],
+            ),
+            ("Curves", ["value:descr"]),
+            ("Parameter", ["value:descr"]),
+        ]
+    ),
+    2.0: OrderedDict(
+        [
+            ("Version", ["value:descr"]),
+            ("Well", ["value:descr"]),
+            ("Curves", ["value:descr"]),
+            ("Parameter", ["value:descr"]),
+        ]
+    ),
+}
 
 DEPTH_UNITS = {
-    'FT': ("FT", "F", "FEET", "FOOT"),
-    'M': ("M", "METER", "METERS", "METRE", "METRES"),
-    }
+    "FT": ("FT", "F", "FEET", "FOOT"),
+    "M": ("M", "METER", "METERS", "METRE", "METRES", "метер", "м"),
+}
 
 READ_POLICIES = {
-    'default': ['comma-decimal-mark', 'run-on(-)', 'run-on(.)', 'run-on(NaN.)'],
-    }
+    "default": ["comma-decimal-mark", "run-on(-)", "run-on(.)", "run-on(NaN.)"]
+}
 
 READ_SUBS = {
-    'comma-decimal-mark': [(re.compile(r'(\d),(\d)'), r'\1.\2'), ],
-    'run-on(-)': [(re.compile(r'(\d)-(\d)'), r'\1 -\2'), ],
-    'run-on(.)': [(re.compile(r'-?\d*\.\d*\.\d*'), ' NaN NaN '), ],
-    'run-on(NaN.)': [(re.compile(r'NaN[\.-]\d+'), ' NaN NaN '), ],
-    }
+    "comma-decimal-mark": [(re.compile(r"(\d),(\d)"), r"\1.\2")],
+    "run-on(-)": [(re.compile(r"(\d)-(\d)"), r"\1 -\2")],
+    "run-on(.)": [(re.compile(r"-?\d*\.\d*\.\d*"), " NaN NaN ")],
+    "run-on(NaN.)": [(re.compile(r"NaN[\.-]\d+"), " NaN NaN ")],
+}
 
 NULL_POLICIES = {
-    'none': [],
-    'strict': ['NULL', ],
-    'common': ['NULL', '(null)', '-',
-               '9999.25', '999.25', 'NA', 'INF', 'IO', 'IND'],
-    'aggressive': ['NULL', '(null)', '--',
-                   '9999.25', '999.25', 'NA', 'INF', 'IO', 'IND',
-                   '999', '999.99', '9999', '9999.99' '2147483647', '32767',
-                   '-0.0', ],
-    'all': ['NULL', '(null)', '-',
-            '9999.25', '999.25', 'NA', 'INF', 'IO', 'IND',
-            '999', '999.99', '9999', '9999.99' '2147483647', '32767', '-0.0',
-            'numbers-only', ],
-    'numbers-only': ['numbers-only', ]
-    }
+    "none": [],
+    "strict": ["NULL"],
+    "common": ["NULL", "(null)", "-", "9999.25", "999.25", "NA", "INF", "IO", "IND"],
+    "aggressive": [
+        "NULL",
+        "(null)",
+        "--",
+        "9999.25",
+        "999.25",
+        "NA",
+        "INF",
+        "IO",
+        "IND",
+        "999",
+        "999.99",
+        "9999",
+        "9999.99" "2147483647",
+        "32767",
+        "-0.0",
+    ],
+    "all": [
+        "NULL",
+        "(null)",
+        "-",
+        "9999.25",
+        "999.25",
+        "NA",
+        "INF",
+        "IO",
+        "IND",
+        "999",
+        "999.99",
+        "9999",
+        "9999.99" "2147483647",
+        "32767",
+        "-0.0",
+        "numbers-only",
+    ],
+    "numbers-only": ["numbers-only"],
+}
 
 NULL_SUBS = {
-    'NULL': [None, ],       # special case to be handled in LASFile.read()
-    '999.25': [-999.25, 999.25],
-    '9999.25': [-9999.25, 9999.25],
-    '999.99': [-999.99, 999.99],
-    '9999.99': [-9999.99, 9999.99],
-    '999': [-999, 999],
-    '9999': [-9999, 9999],
-    '2147483647': [-2147483647, 2147483647],
-    '32767': [-32767, 32767],
-    '(null)': [(re.compile(r' \(null\)'), ' NaN'),
-               (re.compile(r'\(null\) '), 'NaN '),
-               (re.compile(r' \(NULL\)'), ' NaN'),
-               (re.compile(r'\(NULL\) '), 'NaN '),
-               (re.compile(r' null'), ' NaN'),
-               (re.compile(r'null '), 'NaN '),
-               (re.compile(r' NULL'), ' NaN'),
-               (re.compile(r'NULL '), 'NaN '), ],
-    '-': [(re.compile(r' -+ '), ' NaN '), ],
-    'NA': [(re.compile(r'(#N/A)[ ]'), 'NaN '),
-           (re.compile(r'[ ](#N/A)'), ' NaN'), ],
-    'INF': [(re.compile(r'(-?1\.#INF)[ ]'), 'NaN '),
-            (re.compile(r'[ ](-?1\.#INF[0-9]*)'), ' NaN'), ],
-    'IO': [(re.compile(r'(-?1\.#IO)[ ]'), 'NaN '),
-           (re.compile(r'[ ](-?1\.#IO)'), ' NaN'), ],
-    'IND': [(re.compile(r'(-?1\.#IND)[ ]'), 'NaN '),
-            (re.compile(r'[ ](-?1\.#IND[0-9]*)'), ' NaN'), ],
-    '-0.0': [(re.compile(r'(-0\.0)[ ]'), 'NaN '),
-             (re.compile(r'[ ](-0\.0)'), ' NaN'), ],
-    'numbers-only': [(re.compile(r'([^ 0-9.\-+]+)[ ]'), 'NaN '),
-                     (re.compile(r'[ ]([^ 0-9.\-+]+)'), ' NaN'), ],
-    }
-
+    "NULL": [None],  # special case to be handled in LASFile.read()
+    "999.25": [-999.25, 999.25],
+    "9999.25": [-9999.25, 9999.25],
+    "999.99": [-999.99, 999.99],
+    "9999.99": [-9999.99, 9999.99],
+    "999": [-999, 999],
+    "9999": [-9999, 9999],
+    "2147483647": [-2147483647, 2147483647],
+    "32767": [-32767, 32767],
+    "(null)": [
+        (re.compile(r" \(null\)"), " NaN"),
+        (re.compile(r"\(null\) "), "NaN "),
+        (re.compile(r" \(NULL\)"), " NaN"),
+        (re.compile(r"\(NULL\) "), "NaN "),
+        (re.compile(r" null"), " NaN"),
+        (re.compile(r"null "), "NaN "),
+        (re.compile(r" NULL"), " NaN"),
+        (re.compile(r"NULL "), "NaN "),
+    ],
+    "-": [(re.compile(r" -+ "), " NaN ")],
+    "NA": [(re.compile(r"(#N/A)[ ]"), "NaN "), (re.compile(r"[ ](#N/A)"), " NaN")],
+    "INF": [
+        (re.compile(r"(-?1\.#INF)[ ]"), "NaN "),
+        (re.compile(r"[ ](-?1\.#INF[0-9]*)"), " NaN"),
+    ],
+    "IO": [
+        (re.compile(r"(-?1\.#IO)[ ]"), "NaN "),
+        (re.compile(r"[ ](-?1\.#IO)"), " NaN"),
+    ],
+    "IND": [
+        (re.compile(r"(-?1\.#IND)[ ]"), "NaN "),
+        (re.compile(r"[ ](-?1\.#IND[0-9]*)"), " NaN"),
+    ],
+    "-0.0": [(re.compile(r"(-0\.0)[ ]"), "NaN "), (re.compile(r"[ ](-0\.0)"), " NaN")],
+    "numbers-only": [
+        (re.compile(r"([^ 0-9.\-+]+)[ ]"), "NaN "),
+        (re.compile(r"[ ]([^ 0-9.\-+]+)"), " NaN"),
+    ],
+}

--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import re
 
 import numpy as np

--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -65,7 +65,7 @@ ORDER_DEFINITIONS = {
 
 DEPTH_UNITS = {
     "FT": ("FT", "F", "FEET", "FOOT"),
-    "M": ("M", "METER", "METERS", "METRE", "METRES", "метер", "м"),
+    "M": ("M", "METER", "METERS", "METRE", "METRES", u"метер", u"м"),
 }
 
 READ_POLICIES = {

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -302,9 +302,21 @@ class LASFile(object):
                     check_units_on.append(self.well[mnemonic])
             if len(self.curves) > 0:
                 check_units_on.append(self.curves[0])
+            matches = []
             for index_unit, possibilities in defaults.DEPTH_UNITS.items():
-                if all(i.unit.upper() in possibilities for i in check_units_on):
-                    self.index_unit = index_unit
+                for check_unit in check_units_on:
+                    if any([check_unit.unit == p for p in possibilities]) or any(
+                        [check_unit.unit.upper() == p for p in possibilities]
+                    ):
+                        matches.append(index_unit)
+            matches = set(matches)
+            if len(matches) == 1:
+                self.index_unit = tuple(matches)[0]
+            elif len(matches) == 0:
+                self.index_unit = None
+            else:
+                logger.warning("Conflicting index units found: {}".format(matches))
+                self.index_unit = None
 
     def write(self, file_ref, **kwargs):
         """Write LAS file to disk.

--- a/tests/examples/sample_cyrillic_depth_unit.las
+++ b/tests/examples/sample_cyrillic_depth_unit.las
@@ -1,0 +1,46 @@
+~VERSION INFORMATION
+ VERS.                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
+ WRAP.                  NO:   ONE LINE PER DEPTH STEP
+~WELL INFORMATION BLOCK
+#MNEM.UNIT       DATA TYPE    INFORMATION
+#---------    -------------   ------------------------------
+ STRT.M        1670.000000:
+ STOP.M        1660.000000:
+ STEP.M            -0.1250:
+ NULL.           -999.2500:
+ COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ WELL.                WELL:   ANY ET AL OIL WELL #12
+ FLD .               FIELD:   EDAM
+ LOC .            LOCATION:   A9-16-49-20W3M
+ PROV.            PROVINCE:   SASKATCHEWAN
+ SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY LTD.
+ DATE.            LOG DATE:   25-DEC-1988
+ UWI .      UNIQUE WELL ID:   100091604920W300
+~CURVE INFORMATION
+#MNEM.UNIT      API CODE      CURVE DESCRIPTION
+#---------    -------------   ------------------------------
+ DEPT.метер                      :  1  DEPTH
+ DT  .US/м     		     :  2  SONIC TRANSIT TIME
+ RHOB.K/M3                   :  3  BULK DENSITY
+ NPHI.V/V                    :  4   NEUTRON POROSITY
+ SFLU.OHMM                   :  5  RXO RESISTIVITY
+ SFLA.OHMM                   :  6  SHALLOW RESISTIVITY
+ ILM .OHMM                   :  7  MEDIUM RESISTIVITY
+ ILD .OHMM                   :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT        VALUE       DESCRIPTION
+#---------    -------------   ------------------------------
+ BHT .DEGC         35.5000:   BOTTOM HOLE TEMPERATURE
+ BS  .MM          200.0000:   BIT SIZE
+ FD  .K/M3       1000.0000:   FLUID DENSITY
+ MATR.              0.0000:   NEUTRON MATRIX(0=LIME,1=SAND,2=DOLO)
+ MDEN.           2710.0000:   LOGGING MATRIX DENSITY
+ RMF .OHMM          0.2160:   MUD FILTRATE RESISTIVITY
+ DFD .K/M3       1525.0000:   DRILL FLUID DENSITY
+~Other
+     Note: The logging tools became stuck at 625 meters causing the data
+	   between 625 meters and 615 meters to be invalid.
+~A  DEPTH     DT       RHOB     NPHI     SFLU     SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -369,6 +369,7 @@ def test_index_unit_equals_f():
     las = lasio.read(egfn("autodepthindex_M.las"), index_unit="f")
     assert (las.depth_ft == las.index).all()
 
+
 def test_index_unit_equals_m():
     las = lasio.read(egfn("autodepthindex_M.las"), index_unit="m")
     assert (las.depth_ft[1:] != las.index[1:]).all()
@@ -377,6 +378,7 @@ def test_index_unit_equals_m():
 def test_read_incorrect_shape():
     with pytest.raises(ValueError):
         lasio.read(egfn("sample_lastcolblanked.las"))
+
 
 def test_dot_delimiter_issue_264():
     l = lasio.read(stegfn("1.2", "issue-264-dot-delimiter.las"))
@@ -387,20 +389,9 @@ def test_dot_delimiter_issue_264():
         "GAMMA",
         "I. RES.",
     ]
-    assert [c.unit for c in l.curves] == [
-        "FT",
-        "M/MIN",
-        "MS/M",
-        "CPS",
-        "OHM-M",
-    ]
-    assert [c.value for c in l.curves] == [
-        "",
-        "",
-        "",
-        "",
-        "",
-    ]
+    assert [c.unit for c in l.curves] == ["FT", "M/MIN", "MS/M", "CPS", "OHM-M"]
+    assert [c.value for c in l.curves] == ["", "", "", "", ""]
+
 
 def test_issue_201_non_delimiter_colon_start():
     las = lasio.read(egfn("colon_pick_start.las"))
@@ -409,12 +400,14 @@ def test_issue_201_non_delimiter_colon_start():
     assert las.params["TIML"].value == "23:15 23-JAN-2001"
     assert las.params["TIML"].descr == "Time Logger: At Bottom"
 
+
 def test_issue_201_non_delimiter_colon_end():
     las = lasio.read(egfn("colon_pick_end.las"))
     assert las.params["TCS"].descr == "Time Circ. Stopped"
     assert las.params["TIML"].unit == "hh:mm"
     assert las.params["TIML"].value == "23:15 23-JAN-2001"
     assert las.params["TIML"].descr == "Time Logger At Bottom:"
+
 
 def test_header_only_file():
     las = lasio.read(egfn("header_only.las"))
@@ -424,3 +417,8 @@ def test_header_only_file():
     assert las.curves[0].unit == "ft"
     assert las.curves[12].mnemonic == "WPHI_FIT[1]"
     assert len(las.curves) == 21
+
+
+def test_read_cyrillic_depth_unit():
+    las = lasio.read(egfn("sample_cyrillic_depth_unit.las"))
+    assert las.index_unit == "M"

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import os, sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -1,13 +1,22 @@
-import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from pprint import pprint
 
 from lasio.reader import read_header_line
 
+
 def test_time_str_and_colon_in_desc():
-    line = 'TIML.hh:mm 23:15 23-JAN-2001:   Time Logger: At Bottom'
-    result = read_header_line(line, section_name='Parameter')
+    line = "TIML.hh:mm 23:15 23-JAN-2001:   Time Logger: At Bottom"
+    result = read_header_line(line, section_name="Parameter")
     # print('\n')
     # pprint(result)
-    assert( result['value'] == '23:15 23-JAN-2001' )
-    assert( result['descr'] == 'Time Logger: At Bottom' )
+    assert result["value"] == "23:15 23-JAN-2001"
+    assert result["descr"] == "Time Logger: At Bottom"
+
+
+def test_cyrillic_depth_unit():
+    line = " DEPT.метер                      :  1  DEPTH"
+    result = read_header_line(line, section_name="Curves")
+    assert result["unit"] == "метер"

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -17,6 +17,6 @@ def test_time_str_and_colon_in_desc():
 
 
 def test_cyrillic_depth_unit():
-    line = " DEPT.метер                      :  1  DEPTH"
+    line = u" DEPT.метер                      :  1  DEPTH"
     result = read_header_line(line, section_name="Curves")
     assert result["unit"] == "метер"

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -21,4 +21,4 @@ def test_time_str_and_colon_in_desc():
 def test_cyrillic_depth_unit():
     line = u" DEPT.метер                      :  1  DEPTH"
     result = read_header_line(line, section_name="Curves")
-    assert result["unit"] == "метер"
+    assert result["unit"] == u"метер"


### PR DESCRIPTION
This fixes #75 by adding a Cyrillic variant for metres, and also tweaks the automatic detection of depth/index units.

Previously `las.index_unit` was only set to `'M'` if all of the STRT, STOP, STEP and index curve units were the same. I think this is more appropriate a function of something that checks for LAS file correctness. That's not the purpose of lasio, which is to provide immediate and comprehensive accessibility to data. I think as long as the units of those mnemonics are all compatible i.e. all variants of metres, then the index unit should be set to `'M'`. That's what this PR implements.