### PR TITLE
Add a simple deprecation docstring to to_json_old()

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -863,6 +863,10 @@ class LASFile(object):
         return self.to_json()
 
     def to_json_old(self):
+        """
+        deprecated: to_json_old version=0.25.1 since=20200507 remove=20210508
+        replacement_options: json()
+        """
         obj = OrderedDict()
         for name, section in self.sections.items():
             try:

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -865,7 +865,7 @@ class LASFile(object):
     def to_json_old(self):
         """
         deprecated: to_json_old version=0.25.1 since=20200507 remove=20210508
-        replacement_options: json()
+        replacement_options: to_json()
         """
         obj = OrderedDict()
         for name, section in self.sections.items():


### PR DESCRIPTION
This change proposes a text docstring format for documenting deprecated functions and planning for their eventual removal.

Here is the format used in as implemented in this pull request:
deprecated: <funct_name> <last_ver_tag_pre_deprecation> <since_date> <rm_on_date>
replacement_options: <list of replacement functions>

```python
"""    
deprecated: to_json_old version=0.25.1 since=20200507 remove=20210508
replacement_options: json()
"""
```
Benefits:
- This enables the project to be search for all deprecation notices. 
- It makes sure that developers have time to change code using the deprecated function.
- It helps make sure the function is eventually removed from the code base.
- It doesn't require any extra code.

On the other hand there are several active and mature deprecation modules available:
- https://pypi.org/project/deprecation/
- https://pypi.org/project/Deprecated/

If one of those or something else or nothing is preferred this change can be rejected.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC



