### PR TITLE
Fix deprecation warnings reported in test runs

### DIFF
--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -54,7 +54,7 @@ def version():
 
 
 def _get_vcs_version():
-    semver_regex = re.compile('^v\d+\.\d+\.\d+') # examples: 'v0.0.0', 'v0.25.0'
+    semver_regex = re.compile(r'^v\d+\.\d+\.\d+') # examples: 'v0.0.0', 'v0.25.0'
     split_regex = re.compile('-')
     local_las_version = ''
     tmpstr = ''

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -288,7 +288,7 @@ def test_comma_decimal_mark_params():
 
 def test_missing_a_section():
     las = lasio.read(egfn("missing_a_section.las"))
-    assert not las.data
+    assert not las.data.size > 0
 
 
 def test_blank_line_in_header():


### PR DESCRIPTION
- test_read.py::test_missing_a_section
  DeprecationWarning: use `array.size > 0` to check that an array is
  not empty. In this test we check that the array is empty, so `not
  array.size > 0`.
- las/las_version.py
  DeprecationWarning: invalid escape sequence \d
  The solution is to use raw strings for regexs: r"\d" instead of "\d".

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC