### PR TITLE
Add fix for meta-data parameter section parsing for #333

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -324,7 +324,7 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
                }
                sect_lines = []
                sect_line_nos = []
-        
+
 
             if not ignore_data:
                 try:
@@ -743,6 +743,9 @@ def read_header_line(line, pattern=None, section_name=None):
 
     Arguments:
         line (str): line from a LAS header section
+        section_name (str): Name of the section the 'line' is from. The default
+        value is None.
+
 
     Returns:
         A dictionary with keys 'name', 'unit', 'value', and 'descr', each
@@ -756,18 +759,16 @@ def read_header_line(line, pattern=None, section_name=None):
     m = None
 
     if pattern is None:
-        patterns = configure_and_match_pattern(line, section_name)
+        patterns = configure_metadata_patterns(line, section_name)
     else: # pattern was passed in on function call
         patterns.append(pattern)
-        m = re.match(pattern, line)
 
     for pattern in patterns:
+        # Attempt to parse the section line's name(mnemonic), unit, value and
+        # descr fields with the given pattern.
         m = re.match(pattern, line)
         if m is not None:
             break
-
-    if m is None:
-        logger.warning("Unable to parse line as LAS header: {}".format(line))
 
     mdict = m.groupdict()
     for key, value in mdict.items():
@@ -777,18 +778,17 @@ def read_header_line(line, pattern=None, section_name=None):
                 d[key] = d[key].strip(".")  # see issue #36
     return d
 
-def configure_and_match_pattern(line, section_name):
-    """Configure a regular expression pattern and try to match it with the line
+def configure_metadata_patterns(line, section_name):
+    """Configure regular-expression patterns to parse section meta-data lines.
 
     Arguments:
         line (str): line from LAS header section
-        section_name (str): Name of the section the 'line' is from
+        section_name (str): Name of the section the 'line' is from.
 
     Returns:
-        A dictionary with keys 'name', 'unit', 'value', and 'descr', each
-        containing a string as value or the None value.
-
+        An array of regular-expression strings (patterns).
     """
+
     # Default return value
     patterns = []
 

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -12,8 +12,6 @@ from lasio.reader import read_header_line
 def test_time_str_and_colon_in_desc():
     line = "TIML.hh:mm 23:15 23-JAN-2001:   Time Logger: At Bottom"
     result = read_header_line(line, section_name="Parameter")
-    # print('\n')
-    # pprint(result)
     assert result["value"] == "23:15 23-JAN-2001"
     assert result["descr"] == "Time Logger: At Bottom"
 
@@ -22,3 +20,17 @@ def test_cyrillic_depth_unit():
     line = u" DEPT.метер                      :  1  DEPTH"
     result = read_header_line(line, section_name="Curves")
     assert result["unit"] == u"метер"
+
+
+def test_value_field_with_num_colon():
+    line = "RUN . 01: RUN NUMBER"
+    result = read_header_line(line, section_name="Parameter")
+    assert result["value"] == "01"
+    assert result["descr"] == "RUN NUMBER"
+
+
+def test_non_delimiter_colon_in_desc():
+    line = "QI     .      :         Survey quality: GOOD or BAD versus criteria"
+    result = read_header_line(line, section_name="Parameter")
+    assert result["value"] == ""
+    assert result["descr"] == "Survey quality: GOOD or BAD versus criteria"


### PR DESCRIPTION
This should fix https://github.com/kinverarity1/lasio/issues/333.
It is also related to https://github.com/agile-geoscience/welly/issues/128

- Change the parameter-section's value parsing to first attempt to catch
  values that might have a time-string in them and then if no value is
  found try the standard value_re regular expression. This combination
  is handling all the current test cases.
- Move pattern configuration task to a separate function because it is
  continuing to expand and be complex enough to warrant its own
  function.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC