### PR TITLE
Add tests to improve reader.py test coverage.

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -7,9 +7,10 @@ import pytest
 
 from pathlib import Path
 
-from lasio import read
+from lasio import read, reader
 
 egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", vers, fn)
 
 def test_encoding_attr():
     las = read(egfn("encodings_utf8.las"), autodetect_encoding='cchardet')
@@ -46,3 +47,19 @@ def test_pathlib_utf16bebom_cchardet(): las = read(Path(egfn("encodings_utf16beb
 def test_pathlib_iso88591_cchardet(): las = read(Path(egfn("encodings_iso88591.las")), autodetect_encoding='cchardet')
 def test_pathlib_cp1252_cchardet(): las = read(Path(egfn("encodings_cp1252.las")), autodetect_encoding='cchardet')
 
+def test_adhoc_test_encoding():
+    filename = stegfn("1.2", "sample.las")
+    res = reader.adhoc_test_encoding(filename)
+    assert res == "ascii"
+
+def test_open_with_codecs_no_autodetect():
+    filename = stegfn("1.2", "sample.las")
+    obj, encoding = reader.open_with_codecs(
+        filename, autodetect_encoding=False)
+    assert encoding == "ascii"
+
+def test_open_with_codecs_no_autodetect_chars():
+    filename = stegfn("1.2", "sample.las")
+    obj, encoding = reader.open_with_codecs(
+        filename, autodetect_encoding_chars=0)
+    assert encoding == "ASCII"

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -422,3 +422,24 @@ def test_header_only_file():
 def test_read_cyrillic_depth_unit():
     las = lasio.read(egfn("sample_cyrillic_depth_unit.las"))
     assert las.index_unit == "M"
+
+def test_section_parser_num_except_pass():
+    sp = lasio.reader.SectionParser("~C")
+    assert sp.num(None) == None
+
+def test_adhoc_test_encoding():
+    filename = stegfn("1.2", "sample.las")
+    res = lasio.reader.adhoc_test_encoding(filename)
+    assert res == "ascii"
+
+def test_open_with_codecs_no_autodetect():
+    filename = stegfn("1.2", "sample.las")
+    obj, encoding = lasio.reader.open_with_codecs(
+        filename, autodetect_encoding=False)
+    assert encoding == "ascii"
+
+def test_open_with_codecs_no_autodetect_chars():
+    filename = stegfn("1.2", "sample.las")
+    obj, encoding = lasio.reader.open_with_codecs(
+        filename, autodetect_encoding_chars=0)
+    assert encoding == "ASCII"

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -427,19 +427,3 @@ def test_section_parser_num_except_pass():
     sp = lasio.reader.SectionParser("~C")
     assert sp.num(None) == None
 
-def test_adhoc_test_encoding():
-    filename = stegfn("1.2", "sample.las")
-    res = lasio.reader.adhoc_test_encoding(filename)
-    assert res == "ascii"
-
-def test_open_with_codecs_no_autodetect():
-    filename = stegfn("1.2", "sample.las")
-    obj, encoding = lasio.reader.open_with_codecs(
-        filename, autodetect_encoding=False)
-    assert encoding == "ascii"
-
-def test_open_with_codecs_no_autodetect_chars():
-    filename = stegfn("1.2", "sample.las")
-    obj, encoding = lasio.reader.open_with_codecs(
-        filename, autodetect_encoding_chars=0)
-    assert encoding == "ASCII"

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -34,3 +34,26 @@ def test_non_delimiter_colon_in_desc():
     result = read_header_line(line, section_name="Parameter")
     assert result["value"] == ""
     assert result["descr"] == "Survey quality: GOOD or BAD versus criteria"
+
+def test_dot_in_name():
+    """issue_264"""
+    line = "I. Res..OHM-M                  "
+    result = read_header_line(line, section_name="Curves")
+    assert result["name"] == "I. Res."
+
+def test_pattern_arg():
+    line = "DEPT.M                      :  1  DEPTH"
+
+    name_re = "\\.?(?P<name>[^.]*)"
+    unit_re = "\\.(?P<unit>[^\\s]*)"
+    value_re = "(?P<value>.*)"
+    colon_delim = ":"
+    descr_re = "(?P<descr>.*)"
+
+    pattern_re = "".join((name_re, unit_re, value_re, colon_delim, descr_re))
+
+    result = read_header_line(line, section_name="Curves", pattern=pattern_re)
+
+    assert result["name"] == "DEPT"
+    assert result["unit"] == "M"
+    assert result["value"] == ""


### PR DESCRIPTION
This pull-request adds a few tests to bring the reader.py test coverage from
```
Name                       Stmts   Miss  Cover
lasio/reader.py              364     50    86%
```
to
```
Name                       Stmts   Miss  Cover
lasio/reader.py              364     33    91%
```

Tests added:
```
test_read.py
    +def test_section_parser_num_except_pass()
    +def test_adhoc_test_encoding()
    +def test_open_with_codecs_no_autodetect()
    +def test_open_with_codecs_no_autodetect_chars()
 ```
```   
test_read_header_line.py
    +def test_dot_in_name()
    +def test_pattern_arg()
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC