### PR TITLE
Update cwls.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a Python 2.7 and 3.3+ package to read and write Log ASCII Standard
 (LAS) files, used for borehole data such as geophysical, geological, or
 petrophysical logs. It's compatible with versions 1.2 and 2.0 of the LAS file
 specification, published by the [Canadian Well Logging
-Society](http://www.cwls.org/las). Support for LAS 3 is [being worked on](https://github.com/kinverarity1/lasio/issues/5). In
+Society](https://www.cwls.org/products/#products-las). Support for LAS 3 is [being worked on](https://github.com/kinverarity1/lasio/issues/5). In
 principle it is designed to read as many types of LAS files as possible,
 including ones containing common errors or non-compliant formatting.
 


### PR DESCRIPTION
This pull request updates the cwls link.  The old link currently goes to a 'not found' page on the cwls.org site.
- Add https to the link
- Go directly to the cwls.org page and location for las specifications.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC