### PR TITLE
Fix 2 test failures

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -122,6 +122,7 @@ class LASFile(object):
 
         logger.debug("Reading {}...".format(str(file_ref)))
 
+        file_obj = ''
         try:
             file_obj, self.encoding = reader.open_file(file_ref, **kwargs)
 

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -644,6 +644,10 @@ def parse_header_items_section(
                 )
             )
         else:
+            # We have arrived at a new section so break and return the previous
+            # section's object.
+            if line.startswith('~'):
+                break
             try:
                 values = read_line(line, section_name=parser.section_name2)
             except:


### PR DESCRIPTION
This pull-request is for fixing 2 of the failing test-cases on the **rearrange-reader** branch.

- test_open_file.py::test_open_incorrect_filename - UnboundLocalError:
  local variable 'file_obj' referenced before assignment
  fix: assign file_obj as empty string before usage.

- test_read.py::test_v12_inf_uwi_leading_zero_value -
  lasio.exceptions.LASHeaderError: Line 18 (section ~P): "~C"
  fix: stop parsing section when we are at a new section.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC