### PR TITLE
Rearrange-Reader: Base leading zero test files on sample.las

### DIFF
--- a/tests/examples/1.2/sample_inf_api_leading_zero.las
+++ b/tests/examples/1.2/sample_inf_api_leading_zero.las
@@ -1,29 +1,46 @@
-~V
-VERS.                  1.2:   CWLS log ASCII Standard -VERSION 1.2
-WRAP.                   NO:     One line per depth step
-~W
-STRT.M            635.0000:
-STOP.M            400.0000:
-STEP.M             -0.1250:
-NULL.              -999.25:
-COMP.              COMPANY:   ANY OIL COMPANY INC.
-WELL.                 WELL:   ANY ET AL A9-16-49-20
-FLD .                FIELD:   EDAM
-LOC .             LOCATION:   A9-16-49-20W3M
-PROV.             PROVINCE:   SASKATCHEWAN
-SRVC.      SERVICE COMPANY:   ANY LOGGING COMPANY INC.
-DATE.             LOG DATE:   13-DEC-86
-API.            API NUMBER:   05001095820000
-~P
-~C
-DEPT.M                    :   DEPTH
-RHOB.K/M3                 :   BULK DENSITY
-NPHI.VOL/VOL              :   NEUTRON POROSITY - SANDSTONE
-MSFL.OHMM                 :   Rxo RESISTIVITY
-SFLA.OHMM                 :   SHALLOW RESISTIVITY
-ILM .OHMM                 :   MEDIUM RESISTIVITY
-ILD .OHMM                 :   DEEP RESISTIVITY
-SP  .MV                   :   SPONTANEOUS POTENTIAL
-~A
- 635.0000     2256.0000   0.4033  22.0781 22.0781 20.3438 3.6660 123.4
- 634.8750     2256.0000   0.4033  22.0781 22.0781 20.3438 3.6660 123.4
+~VERSION INFORMATION
+ VERS.                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
+ WRAP.                  NO:   ONE LINE PER DEPTH STEP
+~WELL INFORMATION BLOCK
+#MNEM.UNIT       DATA TYPE    INFORMATION
+#---------    -------------   ------------------------------
+ STRT.M        1670.000000:
+ STOP.M        1660.000000:
+ STEP.M            -0.1250:
+ NULL.           -999.2500:
+ COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ WELL.                WELL:   ANY ET AL OIL WELL #12
+ FLD .               FIELD:   EDAM
+ LOC .            LOCATION:   A9-16-49-20W3M
+ PROV.            PROVINCE:   SASKATCHEWAN
+ SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY LTD.
+ DATE.            LOG DATE:   25-DEC-1988
+ API .          API NUMBER:   05001095820000
+~CURVE INFORMATION
+#MNEM.UNIT      API CODE      CURVE DESCRIPTION
+#---------    -------------   ------------------------------
+ DEPT.M                      :  1  DEPTH
+ DT  .US/M     		     :  2  SONIC TRANSIT TIME
+ RHOB.K/M3                   :  3  BULK DENSITY
+ NPHI.V/V                    :  4   NEUTRON POROSITY
+ SFLU.OHMM                   :  5  RXO RESISTIVITY
+ SFLA.OHMM                   :  6  SHALLOW RESISTIVITY
+ ILM .OHMM                   :  7  MEDIUM RESISTIVITY
+ ILD .OHMM                   :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT        VALUE       DESCRIPTION
+#---------    -------------   ------------------------------
+ BHT .DEGC         35.5000:   BOTTOM HOLE TEMPERATURE
+ BS  .MM          200.0000:   BIT SIZE
+ FD  .K/M3       1000.0000:   FLUID DENSITY
+ MATR.              0.0000:   NEUTRON MATRIX(0=LIME,1=SAND,2=DOLO)
+ MDEN.           2710.0000:   LOGGING MATRIX DENSITY
+ RMF .OHMM          0.2160:   MUD FILTRATE RESISTIVITY
+ DFD .K/M3       1525.0000:   DRILL FLUID DENSITY
+~Other
+     Note: The logging tools became stuck at 625 meters causing the data
+	   between 625 meters and 615 meters to be invalid.
+~A  DEPTH     DT       RHOB     NPHI     SFLU     SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/examples/1.2/sample_inf_uwi_leading_zero.las
+++ b/tests/examples/1.2/sample_inf_uwi_leading_zero.las
@@ -1,29 +1,46 @@
-~V
-VERS.                  1.2:   CWLS log ASCII Standard -VERSION 1.2
-WRAP.                   NO:     One line per depth step
-~W
-STRT.M            635.0000:
-STOP.M            400.0000:
-STEP.M             -0.1250:
-NULL.              -999.25:
-COMP.              COMPANY:   ANY OIL COMPANY INC.
-WELL.                 WELL:   ANY ET AL A9-16-49-20
-FLD .                FIELD:   EDAM
-LOC .             LOCATION:   A9-16-49-20W3M
-PROV.             PROVINCE:   SASKATCHEWAN
-SRVC.      SERVICE COMPANY:   ANY LOGGING COMPANY INC.
-DATE.             LOG DATE:   13-DEC-86
-UWI .       UNIQUE WELL ID:   05001095820000
-~P
-~C
-DEPT.M                    :   DEPTH
-RHOB.K/M3                 :   BULK DENSITY
-NPHI.VOL/VOL              :   NEUTRON POROSITY - SANDSTONE
-MSFL.OHMM                 :   Rxo RESISTIVITY
-SFLA.OHMM                 :   SHALLOW RESISTIVITY
-ILM .OHMM                 :   MEDIUM RESISTIVITY
-ILD .OHMM                 :   DEEP RESISTIVITY
-SP  .MV                   :   SPONTANEOUS POTENTIAL
-~A
- 635.0000     2256.0000   0.4033  22.0781 22.0781 20.3438 3.6660 123.4
- 634.8750     2256.0000   0.4033  22.0781 22.0781 20.3438 3.6660 123.4
+~VERSION INFORMATION
+ VERS.                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
+ WRAP.                  NO:   ONE LINE PER DEPTH STEP
+~WELL INFORMATION BLOCK
+#MNEM.UNIT       DATA TYPE    INFORMATION
+#---------    -------------   ------------------------------
+ STRT.M        1670.000000:
+ STOP.M        1660.000000:
+ STEP.M            -0.1250:
+ NULL.           -999.2500:
+ COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ WELL.                WELL:   ANY ET AL OIL WELL #12
+ FLD .               FIELD:   EDAM
+ LOC .            LOCATION:   A9-16-49-20W3M
+ PROV.            PROVINCE:   SASKATCHEWAN
+ SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY LTD.
+ DATE.            LOG DATE:   25-DEC-1988
+ UWI .      UNIQUE WELL ID:   05001095820000
+~CURVE INFORMATION
+#MNEM.UNIT      API CODE      CURVE DESCRIPTION
+#---------    -------------   ------------------------------
+ DEPT.M                      :  1  DEPTH
+ DT  .US/M     		     :  2  SONIC TRANSIT TIME
+ RHOB.K/M3                   :  3  BULK DENSITY
+ NPHI.V/V                    :  4   NEUTRON POROSITY
+ SFLU.OHMM                   :  5  RXO RESISTIVITY
+ SFLA.OHMM                   :  6  SHALLOW RESISTIVITY
+ ILM .OHMM                   :  7  MEDIUM RESISTIVITY
+ ILD .OHMM                   :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT        VALUE       DESCRIPTION
+#---------    -------------   ------------------------------
+ BHT .DEGC         35.5000:   BOTTOM HOLE TEMPERATURE
+ BS  .MM          200.0000:   BIT SIZE
+ FD  .K/M3       1000.0000:   FLUID DENSITY
+ MATR.              0.0000:   NEUTRON MATRIX(0=LIME,1=SAND,2=DOLO)
+ MDEN.           2710.0000:   LOGGING MATRIX DENSITY
+ RMF .OHMM          0.2160:   MUD FILTRATE RESISTIVITY
+ DFD .K/M3       1525.0000:   DRILL FLUID DENSITY
+~Other
+     Note: The logging tools became stuck at 625 meters causing the data
+	   between 625 meters and 615 meters to be invalid.
+~A  DEPTH     DT       RHOB     NPHI     SFLU     SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/examples/2.0/sample_2.0_inf_api_leading_zero.las
+++ b/tests/examples/2.0/sample_2.0_inf_api_leading_zero.las
@@ -1,22 +1,47 @@
-~Version Information
-VERS. 2.0: CWLS Log ASCII Standard - VERSION 2.0
-WRAP. NO: One line per depth step
-~Well Information Block
-STRT.FT 1365.0000:
-STOP.FT 8781.0000:
-STEP.FT 0.5000:
-NULL. -999.2500:
-COMP. Windsor Energy Group: COMPANY
-WELL. Christiansen 4-9: WELL
-FLD. Spindle: FIELD
-LOC. SHL: 1536' FNL & 1123' FWL SW NW--BHL: 662' FNL & 691' FWL NWNW--Sec. 9, Twp. 1S, Rge. 67W: LOCATION
-CNTY. Adams: COUNTY
-SRVC. PHOENIX SURVEYS, INC.: SERVICE COMPANY
-DATE. Fri Nov 30 03:06:59 2007: LOG DATE
-API. 05001095820000 : UNIQUE WELL ID
-STAT. Colorado: STATE
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+API     .       05001095820000                   :UNIQUE WELL ID
 ~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
 ~PARAMETER INFORMATION
-~A  DEPTH     DT       RHOB     NPHI     SFLU     SFLA      ILM      ILD
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
 1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
-
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/examples/2.0/sample_2.0_inf_uwi_leading_zero.las
+++ b/tests/examples/2.0/sample_2.0_inf_uwi_leading_zero.las
@@ -1,22 +1,47 @@
-~Version Information
-VERS. 2.0: CWLS Log ASCII Standard - VERSION 2.0
-WRAP. NO: One line per depth step
-~Well Information Block
-STRT.FT 1365.0000:
-STOP.FT 8781.0000:
-STEP.FT 0.5000:
-NULL. -999.2500:
-COMP. Windsor Energy Group: COMPANY
-WELL. Christiansen 4-9: WELL
-FLD. Spindle: FIELD
-LOC. SHL: 1536' FNL & 1123' FWL SW NW--BHL: 662' FNL & 691' FWL NWNW--Sec. 9, Twp. 1S, Rge. 67W: LOCATION
-CNTY. Adams: COUNTY
-SRVC. PHOENIX SURVEYS, INC.: SERVICE COMPANY
-DATE. Fri Nov 30 03:06:59 2007: LOG DATE
-UWI. 05001095820000 : UNIQUE WELL ID
-STAT. Colorado: STATE
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       05001095820000                   :UNIQUE WELL ID
 ~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
 ~PARAMETER INFORMATION
-~A  DEPTH     DT       RHOB     NPHI     SFLU     SFLA      ILM      ILD
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
 1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
-
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600


### PR DESCRIPTION
This pull-request is for fixing 2 of the failing test-cases on the rearrange-reader branch.

Change the leading zero test files to be sample*.las plus the leading
zero special case.  Previously the leading zero test files had other
special cases in them that caused their tests to exercise unrelated code
paths.

These changes remove these test failures:
```
FAILED tests/test_read.py::test_v2_inf_uwi_leading_zero_value
 - ValueError: Cannot reshape ~A data size (8,) into -1 columns

FAILED tests/test_read.py::test_v2_inf_api_leading_zero_value 
 - ValueError: Cannot reshape ~A data size (8,) into -1 columns
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC