### PR TITLE
Rearrange-Reader Branch: Fix test_read::missing-a-section test

### DIFF
--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -288,7 +288,7 @@ def test_comma_decimal_mark_params():
 
 def test_missing_a_section():
     las = lasio.read(egfn("missing_a_section.las"))
-    assert not las.data
+    assert las.data.size == 0
 
 
 def test_blank_line_in_header():


### PR DESCRIPTION
This pull-request fixes 2 tests for the rearrange-reader branch by adding  code-checks for data.size > 0 in several places in las.py.  This reduces the failing tests from by 2.

I think these 2 tests apply to reading any of the LAS versions: 1.2, 2.0, and 3.0.

```
FAILED tests/test_read.py::test_missing_a_section
 - ValueError: Cannot reshape ~A data size (0,) into -1 columns

FAILED tests/test_read.py::test_blank_line_in_header
 - ValueError: Cannot reshape ~A data size (0,) into -1 columns
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC