### PR TITLE
Add test case for well null value

### DIFF
--- a/tests/test_sectionitems.py
+++ b/tests/test_sectionitems.py
@@ -127,6 +127,7 @@ def test_mnemonic_case_comparison_upper():
 def test_mnemonic_case_comparison_lower():
     las = lasio.read(egfn('mnemonic_case.las'), mnemonic_case='lower')
     assert 'DEPT' in las.curves
+    assert las.well.null.value == -999.25
 
 def test_missing_sectionitems_mnemonic():
     las = lasio.read(egfn('sample.las'))


### PR DESCRIPTION
This is a working branch for #350. 

The failing test case is here:
pytest -s -vv tests/test_sectionitems.py::test_mnemonic_case_comparison_lower

Output:
```python
    def test_mnemonic_case_comparison_lower():
        las = lasio.read(egfn('mnemonic_case.las'), mnemonic_case='lower')
        assert 'DEPT' in las.curves
>       assert las.well.null.value == -999.25
E       AssertionError: assert '' == -999.25
E         +''
E         --999.25

tests/test_sectionitems.py:130: AssertionError
```
