### PR TITLE
Issue-350: Add lowercase keys to default..ORDER_DEFINITIONS

### DIFF
--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -49,7 +49,10 @@ ORDER_DEFINITIONS = {
             ("Version", ["value:descr"]),
             (
                 "Well",
-                ["descr:value", ("value:descr", ["STRT", "STOP", "STEP", "NULL"])],
+                ["descr:value", ("value:descr", [
+                    "STRT", "STOP", "STEP", "NULL",
+                    "strt", "stop", "step", "null"
+                ])],
             ),
             ("Curves", ["value:descr"]),
             ("Parameter", ["value:descr"]),

--- a/tests/test_sectionitems.py
+++ b/tests/test_sectionitems.py
@@ -127,6 +127,7 @@ def test_mnemonic_case_comparison_upper():
 def test_mnemonic_case_comparison_lower():
     las = lasio.read(egfn('mnemonic_case.las'), mnemonic_case='lower')
     assert 'DEPT' in las.curves
+    assert las.well.null.value == -999.25
 
 def test_missing_sectionitems_mnemonic():
     las = lasio.read(egfn('sample.las'))


### PR DESCRIPTION
This pull-request resolves #350
- test_mnemonic_case_comparison_lower sets well.null to "" instead of -999.2500.
 
Changes
- Add test case for well null value from a las file with lowercase
  mnemonics.
- Add lowercase keys to the 1.2 Well section of default.py's
  ORDER_DEFINITIONS data structure.  This enables
  SectionItems.metadata() to find the right key_order when reading a las
  file containing lower-case mnemonics in the ~Well section.  key_orders
  are either "descr:value" or "value:descr" order.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC