### PR TITLE
Use universal-newline when reading urllib content

### DIFF
--- a/lasio/examples.py
+++ b/lasio/examples.py
@@ -84,7 +84,10 @@ def open_github_example(
                 encoding = "utf-8"
         else:
             encoding = response.headers.get_content_charset()
-        file_ref = StringIO(response.read().decode(encoding))
+        # newline=None causes StringIO to use universal-newline:
+        # Lines in the input can end in '\n', '\r', or '\r\n', and these are
+        # translated into '\n' before being returned to the caller.
+        file_ref = StringIO(response.read().decode(encoding), newline=None)
     return LASFile(file_ref, **kwargs)
 
 

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -109,7 +109,10 @@ def open_file(file_ref, **encoding_kwargs):
                         encoding = "utf-8"
                 else:
                     encoding = response.headers.get_content_charset()
-                file_ref = StringIO(response.read().decode(encoding))
+                # newline=None causes StringIO to use universal-newline:
+                # Lines in the input can end in '\n', '\r', or '\r\n', and these are
+                # translated into '\n' before being returned to the caller.
+                file_ref = StringIO(response.read().decode(encoding), newline=None)
                 logger.debug("Retrieved data decoded via {}".format(encoding))
         elif len(lines) > 1:  # it's LAS data as a string.
             file_ref = StringIO(file_ref)


### PR DESCRIPTION
This pull-request resolves #359 `Not finding sections...`

Use universal-newline in StringIO for reading url responses
This handles cases where a file has mixed '\r\n' and '\r'
line endings.

References:
- https://docs.python.org/3/library/io.html#io.StringIO
- https://docs.python.org/3/library/io.html#io.TextIOWrapper

The test suite passes.
Note: I didn't add this change to the `urllib2` part of the logic because usage of urllib2 should be in decline.  Let me know if this change should be supported in urlib2 also.

I am still working on a test case for  issue #359 and this change. I will post a separate pull-request for it. 

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
