### PR TITLE
Update newline test to las file in master repo

### DIFF
--- a/tests/test_open_file.py
+++ b/tests/test_open_file.py
@@ -22,8 +22,9 @@ def test_open_url():
 
 
 def test_open_url_different_newlines():
-    las = read("https://raw.githubusercontent.com/dcslagel/"
-             "lasio/add-universal-newline-testcase/tests/examples/2.0/sample_2.0_universal_newline.las")
+    las = read("https://raw.githubusercontent.com/kinverarity1/"
+               "lasio/master/tests/examples"
+               "/2.0/sample_2.0_universal_newline.las")
     assert las.well.keys() == [
         'STRT',
         'STOP',


### PR DESCRIPTION
This change redirects the test_open_url_different_newlines
test to seek the example test file in the master branch of the
https://kinverarity1/lasio repo which is the master source
repo.