### PR TITLE
Rearrange-Reader: Enable Unknown section tests to pass

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -705,18 +705,25 @@ class SectionParser(object):
             self.func = self.metadata
             self.section_name2 = "Version"
         else:
-            raise KeyError("Unknown section name {}".format(title.upper()))
+            # raise KeyError("Unknown section name {}".format(title.upper()))
+            print("Unknown section name {}".format(title.upper()))
+            self.func = self.metadata
+            self.section_name2 = title
+            self.default_order = 'value:descr'
+            self.orders = {}
 
         self.version = version
         self.section_name = title
 
         defs = defaults.ORDER_DEFINITIONS
-        section_orders = defs[self.version][self.section_name2]
-        self.default_order = section_orders[0]  #
-        self.orders = {}
-        for order, mnemonics in section_orders[1:]:
-            for mnemonic in mnemonics:
-                self.orders[mnemonic] = order
+
+        if self.section_name2 in defs[self.version]:
+            section_orders = defs[self.version][self.section_name2]
+            self.default_order = section_orders[0]  #
+            self.orders = {}
+            for order, mnemonics in section_orders[1:]:
+                for mnemonic in mnemonics:
+                    self.orders[mnemonic] = order
 
     def __call__(self, **keys):
         """Return the correct object for this type of section.

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -705,8 +705,7 @@ class SectionParser(object):
             self.func = self.metadata
             self.section_name2 = "Version"
         else:
-            # raise KeyError("Unknown section name {}".format(title.upper()))
-            print("Unknown section name {}".format(title.upper()))
+            logger.info("Unknown section name {}".format(title.upper()))
             self.func = self.metadata
             self.section_name2 = title
             self.default_order = 'value:descr'


### PR DESCRIPTION
This pull-request enables the current enhancement tests of 1.2 version files with unknown sections.

This pull-request enables these 2 tests to pass on the Rearrange-Reader Branch for Python3:
```
FAILED tests/test_enhancements.py::test_non_standard_section
- KeyError: 'Unknown section name ~SPECIAL INFORMATION'

FAILED tests/test_enhancements.py::test_non_standard_sections
- KeyError: 'Unknown section name ~SPECIAL INFORMATION'
```

Remaining 19 failing tests:
```
 tests/test_json.py::test_json_null
- assert '{"data": {"D... WELL #12"}}}' == '{"data": {"D... WELL #12"}}}'

tests/test_null_policy.py::test_null_policy_NULL_none
- assert nan == -999.25
tests/test_null_policy.py::test_null_policy_custom_2
- assert nan == -999.25
tests/test_null_policy.py::test_null_policy_runon_replaced_1
- ValueError: Cannot reshape ~A data size (35,) into -1 columns
tests/test_null_policy.py::test_null_policy_runon_replaced_2
- ValueError: Cannot reshape ~A data size (35,) into -1 columns
tests/test_null_policy.py::test_null_policy_runon_ok_1
- ValueError: Cannot reshape ~A data size (35,) into -1 columns
tests/test_null_policy.py::test_null_policy_runon_ok_2
- ValueError: Cannot reshape ~A data size (35,) into -1 columns

tests/test_write.py::test_write_sect_widths_12
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
tests/test_write.py::test_write_sect_widths_20_narrow
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
tests/test_write.py::test_write_sect_widths_20_wide
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
tests/test_write.py::test_df_curve_addition_on_export
- AssertionError: assert '~Version ---...    9.46970\n' == '~Version ---...    9.46970\n'
tests/test_write.py::test_multi_curve_mnemonics_rewrite
- AssertionError: assert '~Version ---...    0.30000\n' == '~Version ---...    0.30000\n'
tests/test_write.py::test_multi_curve_missing_mnemonics_rewrite
- AssertionError: assert '~Version ---...    0.30000\n' == '~Version ---...    0.30000\n'
tests/test_write.py::test_write_units
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
tests/test_write.py::test_rename_and_write_curve_mnemonic
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
tests/test_write.py::test_write_single_step
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
tests/test_write.py::test_write_12_to_20_ver_in_mem_is_12
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
tests/test_write.py::test_write_12_to_20_ver
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
tests/test_write.py::test_write_20_to_12_ver_in_mem_is_20
- AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
```