### PR TITLE
Rearrange Reader:  fix json and write tests

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -196,8 +196,10 @@ class LASFile(object):
                     line_no = first_line
                     contents = []
                     for line in file_obj:
+                        if line.startswith('~'):
+                            continue
                         line_no += 1
-                        contents.append(line.strip("\n"))
+                        contents.append(line.strip("\n").strip())
                         if line_no == last_line:
                             break
                     sct_contents = "\n".join(contents)


### PR DESCRIPTION
This pull-request fixes the previously broken tests on the rearrange-reader branch.

The change checks for and skips the header line ('~') when gathering the contents for a "Header (other)" section and strips leading and trailing whitespace from each content line.

Here are the tests fixed with this change:  
```
tests/test_json.py::test_json_null
tests/test_write.py::test_write_sect_widths_20_narrow
tests/test_write.py::test_write_sect_widths_20_wide
tests/test_write.py::test_df_curve_addition_on_export
tests/test_write.py::test_multi_curve_mnemonics_rewrite
tests/test_write.py::test_multi_curve_missing_mnemonics_rewrite
tests/test_write.py::test_write_units
tests/test_write.py::test_rename_and_write_curve_mnemonic
tests/test_write.py::test_write_single_step
tests/test_write.py::test_write_12_to_20_ver_in_mem_is_12
tests/test_write.py::test_write_12_to_20_ver
tests/test_write.py::test_write_20_to_12_ver_in_mem_is_20
```

NOTES! :

1. The change in this pull-request doesn't seem to relate to the test_write.py test failures.   
I'm checking further on that and will have an update in a few days.
    - Finding:  the test_write.py failures did have the same underlying issue as the json tests.
       They were all including the ~Other section header in the section records so they didn't 
       match the expected results.
       So the same fix correctly applies to all the files and functions listed above.
<nbsp/>

2. There are 221 tests on the master branch and only 197 on the rearrange-reader branch.
The 24 additional tests on master should be migrated to the rearrange-reader branch and checked.


REMAINING:
There are 7 remaining failing tests as follows:
```python
tests/test_null_policy.py::test_null_policy_NULL_none
 - assert nan == -999.25

tests/test_null_policy.py::test_null_policy_custom_2
 - assert nan == -999.25

tests/test_null_policy.py::test_null_policy_runon_replaced_1
 - ValueError: Cannot reshape ~A data size (35,) into -1 columns

tests/test_null_policy.py::test_null_policy_runon_replaced_2
 - ValueError: Cannot reshape ~A data size (35,) into -1 columns

tests/test_null_policy.py::test_null_policy_runon_ok_1
 - ValueError: Cannot reshape ~A data size (35,) into -1 columns

tests/test_null_policy.py::test_null_policy_runon_ok_2
 - ValueError: Cannot reshape ~A data size (35,) into -1 columns

tests/test_write.py::test_write_sect_widths_12
 - AssertionError: assert '~Version ---...  105.60000\n' == '~Version ---...  105.60000\n'
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC