### PR TITLE
Merge to Rearrange-Reader: Add check if null should be replaced with nan

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -234,7 +234,13 @@ class LASFile(object):
 
                     if data.size > 0:
                         # TODO: check whether this treatment of NULLs is correct
-                        arr[arr == provisional_null] = np.nan
+                        logger.debug("~A data {}".format(arr))
+                        if version_NULL:
+                            arr[arr == provisional_null] = np.nan
+                        logger.debug(
+                            "~A after NULL replacement data {}".format(arr)
+                        )
+
 
                         # Provisionally, assume that the number of columns represented
                         # by the data section's array is equal to the number of columns


### PR DESCRIPTION
- fixes tests/test_null_policy.py::test_null_policy_NULL_none

While I'm pretty sure this is a good place in the code to fix this, I'm not fully confident that version_NULL is the right check for `arr[arr == provisional_null] = np.nan`.   It might be NULL_POLICIES or NULL_SUBS that needs to be the check variable.  Could you check it and advise?


Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
