### PR TITLE
To Rearrange-Reader branch: Fix 5 tests : calculating number of data columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.7"
     - "3.5"
     - "3.6"
     - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
+before_install:
+  - pip install -U pip
+  - pip install -U pytest
 install:
   - pip install --editable ".[all]"
   - pip install pytest>=3.6 pytest-cov coverage pathlib

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -255,8 +255,7 @@ class LASFile(object):
                         # section's number of columns instead.
 
                         if provisional_wrapped == "NO":
-                            if len(self.curves) > n_columns:
-                                n_columns_in_arr = n_columns
+                            n_columns_in_arr = n_columns
 
                         #---------------------------------------------------------------------
                         # TODO:

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -221,7 +221,7 @@ class LASFile(object):
 
                     file_obj.seek(k)
                     n_columns = reader.inspect_data_section(
-                        file_obj, (first_line, last_line)
+                        file_obj, (first_line, last_line), regexp_subs
                     )
 
                     file_obj.seek(k)

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -449,7 +449,7 @@ def read_file_contents(file_obj, regexp_subs, value_null_subs, ignore_data=False
     return sections
 
 
-def inspect_data_section(file_obj, line_nos):
+def inspect_data_section(file_obj, line_nos, regexp_subs):
     """Determine how many columns there are in the data section.
 
     Arguments:
@@ -467,6 +467,8 @@ def inspect_data_section(file_obj, line_nos):
     for i, line in enumerate(file_obj):
         line_no = line_no + 1
         line = line.strip("\n").strip()
+        for pattern, sub_str in regexp_subs:
+            line = re.sub(pattern, sub_str, line)
         n_items = len(line.split())
         logger.debug("Line {}: {} items counted in '{}'".format(line_no + 1, n_items, line))
         item_counts.append(n_items)

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -455,6 +455,9 @@ def inspect_data_section(file_obj, line_nos, regexp_subs):
     Arguments:
         file_obj: file-like object open for reading at the beginning of the section
         line_nos (tuple): the first and last line no of the section to read
+        regexp_subs (list): each item should be a tuple of the pattern and
+            substitution string for a call to re.sub() on each line of the
+            data section. See defaults.py READ_SUBS and NULL_SUBS for examples.
 
     Returns: integer number of columns or -1 where they are different.
 


### PR DESCRIPTION
This pull-request fixes the remaining previously broken tests on the rearrange-reader branch.

**It also, removes python 2.7 from Travis-CI. Per #364, Python 2.7 won't be supported on the rearrange-reader branch.**

This change adds parsing a data line with regexp_subs which fixes common errors in the data
(~A).  It  is added to reader.py::inspect_data_section().  inspect_data_section() is a new function
on the rearrange_reader branch that replaces the older  "get data line length" steps.
This change is essentially pulling the regex_subs loop from the older steps and adding it to the
new inspect_data_section() function.

This change also accepts the n_columns from insect_data_section() if provisional_wrap is "NO".

API change:
This change adds regex_subs to inspect_data_section's parameter list:
from 
`inspect_data_section(file_obj, line_nos)`
to
`inspect_data_section(file_obj, line_nos, regexp_subs)`

Here are the tests fixed with this change:  
```
tests/test_null_policy.py::test_null_policy_runon_replaced_1
tests/test_null_policy.py::test_null_policy_runon_replaced_2
tests/test_null_policy.py::test_null_policy_runon_ok_1
tests/test_null_policy.py::test_null_policy_runon_ok_2
tests/test_write.py::test_write_sect_widths_12
```



### Additional-Notes:    
`def inspect_data_section(file_obj, line_nos, regexp_subs)` and `def read_data_section_iterative(file_obj, line_nos, regexp_subs, value_null_subs)` have a fair amount of code in common.  A future issue/pull-request might work to
combine the common code.

### Test and Coverage comparison with master branch

#### rearrange-reader + this change
```
204 passed, 1 skipped, 8 warnings

Name                      Stmts   Miss  Cover
---------------------------------------------
lasio/__init__.py            13      2    85%
lasio/defaults.py            11      0   100%
lasio/examples.py            42     10    76%
lasio/excel.py               88     34    61%
lasio/exceptions.py           6      0   100%
lasio/las.py                364     54    85%
lasio/las_items.py          190     39    79%
lasio/las_version.py         34     22    35%
lasio/reader.py             420     91    78%
lasio/tmp-master-las.py     388    388     0%
lasio/writer.py             160      9    94%
---------------------------------------------
TOTAL                      1716    649    62%
```

#### master branch

```
221 passed, 2 skipped, 5 warning

Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 388     46    88%
lasio/las_items.py           190     31    84%
lasio/las_version.py          34     22    35%
lasio/reader.py              365     36    90%
lasio/tmp-master-las.py      388    388     0%
lasio/writer.py              160      9    94%
----------------------------------------------
TOTAL                       1705    598    65%
```


Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
