### PR TITLE
Issue-377: Add writing Nonetype as empty string

### DIFF
--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -248,12 +248,23 @@ def write(
 
 
 def standardize_value(value, unit=None):
-    # If an internal representation of a metadata mnemonic has a unit
-    # indicator and a zero value, empty string, or NoneType, then on
-    # lasio.write(...) the value should write a 0 for the value field
-    # instead of "None" or "".
+    """Ensure that 0 is written instead of 'None' for numeric header lines.
+    
+    Args:
+        value (anything): object to be written into the value field
+            of the LAS header line.
+        unit (str): unit for header line.
+        
+    Returns: either 0 (integer) or a string.
+    
+    If an internal representation of a metadata mnemonic has a unit
+    indicator and a value of zero, an empty string, or None, then on
+    lasio.write(...) the value written should be 0 for the value field
+    instead of "None" or "".
+    
+    """
     # value != 0 prevents overwriting a 0.0 value with 0.
-    if unit and not value and value != 0:
+    if (unit) and (not value) and (value != 0):
         value = 0
     if value is None:
         value = ""

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -274,16 +274,19 @@ def get_formatter_function(order, left_width=None, middle_width=None):
         + " " * (middle_width - len(str(unit)) - len(right_hand_item))
         + right_hand_item
     )
+    def nonetype_to_str(value):
+        return "" if value is None else value
+
     if order == "descr:value":
         return lambda item: "%s.%s : %s" % (
             mnemonic_func(item.original_mnemonic),
             middle_func(str(item.unit), str(item.descr)),
-            item.value,
+            nonetype_to_str(item.value),
         )
     elif order == "value:descr":
         return lambda item: "%s.%s : %s" % (
             mnemonic_func(item.original_mnemonic),
-            middle_func(str(item.unit), str(item.value)),
+            middle_func(str(item.unit), str(nonetype_to_str(item.value))),
             item.descr,
         )
 

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -146,6 +146,7 @@ def write(
     section_widths = get_section_widths("Well", las.well, version, order_func)
     # logger.debug('LASFile.write well section_widths=%s' % section_widths)
     for header_item in las.well.values():
+        header_item.value = standardize_value(header_item.value, header_item.unit)
         mnemonic = header_item.original_mnemonic
         order = order_func(mnemonic)
         logger.debug(
@@ -174,6 +175,7 @@ def write(
     order_func = get_section_order_function("Parameter", version)
     section_widths = get_section_widths("Parameter", las.params, version, order_func)
     for header_item in las.params.values():
+        header_item.value = standardize_value(header_item.value, header_item.unit)
         mnemonic = header_item.original_mnemonic
         order = order_func(mnemonic)
         formatter_func = get_formatter_function(order, **section_widths)
@@ -245,6 +247,19 @@ def write(
             line_counter += 1
 
 
+def standardize_value(value, unit=None):
+    # If an internal representation of a metadata mnemonic has a unit
+    # indicator and a zero value, empty string, or NoneType, then on
+    # lasio.write(...) the value should write a 0 for the value field
+    # instead of "None" or "".
+    # value != 0 prevents overwriting a 0.0 value with 0.
+    if unit and not value and value != 0:
+        value = 0
+    if value is None:
+        value = ""
+    return value
+
+
 def get_formatter_function(order, left_width=None, middle_width=None):
     """Create function to format a LAS header item for output.
 
@@ -274,19 +289,17 @@ def get_formatter_function(order, left_width=None, middle_width=None):
         + " " * (middle_width - len(str(unit)) - len(right_hand_item))
         + right_hand_item
     )
-    def nonetype_to_str(value):
-        return "" if value is None else value
 
     if order == "descr:value":
         return lambda item: "%s.%s : %s" % (
             mnemonic_func(item.original_mnemonic),
             middle_func(str(item.unit), str(item.descr)),
-            nonetype_to_str(item.value),
+            item.value,
         )
     elif order == "value:descr":
         return lambda item: "%s.%s : %s" % (
             mnemonic_func(item.original_mnemonic),
-            middle_func(str(item.unit), str(nonetype_to_str(item.value))),
+            middle_func(str(item.unit), str(item.value)),
             item.descr,
         )
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -457,7 +457,7 @@ WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
 STRT.M                  1670.0 : START DEPTH
 STOP.M                  1670.0 : STOP DEPTH
-STEP.M                    None : STEP
+STEP.M                       0 : STEP
 NULL.                  -999.25 : NULL VALUE
 COMP.     ANY OIL COMPANY INC. : COMPANY
 WELL.                  AAAAA_2 : WELL

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -638,3 +638,18 @@ between 625 metres and 615 metres to be invalid.
  1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
  1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
 '''
+
+
+def test_write_empty_text_value():
+    las = read(egfn("sample.las"))
+    las.well.well.value = ""
+    las.well.comp.value = None
+    las.write('test.las', version=2.0)
+
+    las2 = read("test.las")
+    assert las2.well.well.value == ""
+    assert las2.well.well.unit == ""
+    assert las2.well.comp.value == ""
+    assert las2.well.comp.unit == ""
+
+    os.remove('test.las')


### PR DESCRIPTION
This pull-request is related to issue 377 "Lasio is writing the python None object to the string 'None' when writing HeaderItems to a file"

It implements the suggested solution except with a function instead of a lambda.  The reason is that the function is self-documenting.  If a lambda is preferred let me know and I can make the change.

This pull-request is in draft mode until new testing is added and test failures are fixed:
`FAILED tests/test_write.py::test_write_single_step`

