### PR TITLE
Issue-380 Improve error handling in call to git

### DIFF
--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -1,6 +1,9 @@
 import subprocess, re
 from pkg_resources import get_distribution, DistributionNotFound
 from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
 
 # d[year][month][day] example: 20200420
 ver_date = datetime.now().strftime("d%Y%m%d")
@@ -26,11 +29,10 @@ def version():
     release installed with 'pip install "."'
     '''
 
-
     try:
         las_version = get_distribution(__package__).version
-    except DistributionNotFound:
-        # TODO: Add logger message
+    except DistributionNotFound as err:
+        logger.debug(err)
         pass
 
     '''
@@ -42,23 +44,30 @@ def version():
 
     '''
     Else set a sensible default version
-    0.25.0 was the most recent version before this change so it is being
-    used as teh default basline.
+    0.26.0 was the most recent version before this change so it is being
+    used as the default baseline.
     '''
     if not las_version.strip():
         las_version = (
-            "0.25.0.dev0+unknown-post-dist-version.{}".format(ver_date)
+            "0.26.0.dev0+unknown-post-dist-version.{}".format(ver_date)
         )
 
     return las_version
 
 
-def _get_vcs_version():
-    semver_regex = re.compile(r'^v\d+\.\d+\.\d+') # examples: 'v0.0.0', 'v0.25.0'
+def _get_vcs_version(version_cmd=[]):
+    # semver examples: 'v0.0.0', 'v0.25.0'
+    semver_regex = re.compile(r'^v\d+\.\d+\.\d+')
+    # major_minor examples: 'v0.0', 'v0.25'
+    major_minor_regex = re.compile(r'^v\d+\.\d+(?!\.\d+)') 
     split_regex = re.compile('-')
     local_las_version = ''
     tmpstr = ''
     tmpbytes = b''
+
+    # version_cmd: command to retrieve the current version tag
+    if not version_cmd:
+        version_cmd = ["git", "describe", "--tags", "--match", "v*"]
 
     '''
     https://git-scm.com/docs/git-describe
@@ -68,12 +77,19 @@ def _get_vcs_version():
     '''
     try:    
         tmpbytes = subprocess.check_output(
-            ["git", "describe", "--tags", "--match", "v*"],
+            version_cmd,
             stderr=subprocess.STDOUT,
         ).strip()
 
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as err:
+        logger.debug(err)
         pass
+
+    except FileNotFoundError as err:
+        # Usually means that 'git' is not installed or not found
+        logger.debug(err.strerror)
+        pass
+
 
     # Convert byte string to text string
     try:
@@ -87,5 +103,18 @@ def _get_vcs_version():
         local_las_version = "{}.dev{}+{}.{}".format(
             rel_ver, commits_since_rel_ver, current_commit, ver_date
         )
+    elif major_minor_regex.match(tmpstr):
+        # remove 'v' preface
+        tmpstr = tmpstr[1:]
+
+        # set default, usually \d+\.\d+
+        local_las_version = tmpstr
+
+        # add additional detail to the version string if it is available
+        if split_regex.match(tmpstr):
+            (rel_ver, commits_since_rel_ver, current_commit) = split_regex.split(tmpstr)
+            local_las_version = "{}.dev{}+{}.{}".format(
+                rel_ver, commits_since_rel_ver, current_commit, ver_date
+            )
 
     return local_las_version

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import re
+version_regex = re.compile(r'^\d+\.\d+')
+
+import lasio.las_version
+
+
+def test_verify_default_vcs_tool():
+    result = lasio.las_version._get_vcs_version()
+    assert version_regex.match(result) 
+
+def test_non_existant_vcs_tool():
+    version_cmd = ["gt", "describe", "--tags", "--match", "v*"]
+    result = lasio.las_version._get_vcs_version(version_cmd)
+    assert result == ""
+
+
+def test_explicit_existant_vcs_tool():
+    version_cmd = ["git", "describe", "--tags", "--match", "v*"]
+    result = lasio.las_version._get_vcs_version(version_cmd)
+    assert version_regex.match(result) 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,13 +13,13 @@ def test_verify_default_vcs_tool():
     result = lasio.las_version._get_vcs_version()
     assert version_regex.match(result) 
 
-def test_non_existant_vcs_tool():
+def test_non_existent_vcs_tool():
     version_cmd = ["gt", "describe", "--tags", "--match", "v*"]
     result = lasio.las_version._get_vcs_version(version_cmd)
     assert result == ""
 
 
-def test_explicit_existant_vcs_tool():
+def test_explicit_existent_vcs_tool():
     version_cmd = ["git", "describe", "--tags", "--match", "v*"]
     result = lasio.las_version._get_vcs_version(version_cmd)
     assert version_regex.match(result) 


### PR DESCRIPTION
This pull-request is a proposal for fixing issue #380.

#### Changes

- Add FileNotFound exception catch for the case of `git` not installed or not found
- Make the version control system command a parameter of the _get_vcs_version() function so we can test it.
- Added new test file `lasio/las_version.py`.
- Add tests to check that if git isn't available, las_version will continue to run with the next option for getting the version.
- Add comments and logging to las_version.py. 
- Improve version handling for version numbers with only major and minor fields: example: v0.26, v0.4.

#### Test results

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 388     46    88%
lasio/las_items.py           190     31    84%
lasio/las_version.py          50     10    80%
lasio/reader.py              365     36    90%
lasio/writer.py              160      9    94%
----------------------------------------------
TOTAL                       1333    198    85%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC