### PR TITLE
Test for GITHUB_WORKFLOW in verison tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,30 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy cchardet openpyxl pandas
+        pip install pytest coverage pytest-cov codecov pathlib
+    - name: Test with pytest
+      run: |
+        pytest --cov-fail-under=80 --cov-branch

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -59,7 +59,7 @@ def _get_vcs_version(version_cmd=[]):
     # semver examples: 'v0.0.0', 'v0.25.0'
     semver_regex = re.compile(r'^v\d+\.\d+\.\d+')
     # major_minor examples: 'v0.0', 'v0.25'
-    major_minor_regex = re.compile(r'^v\d+\.\d+(?!\.\d+)') 
+    major_minor_regex = re.compile(r'^v\d+\.\d+(?!\.\d+)')
     split_regex = re.compile('-')
     local_las_version = ''
     tmpstr = ''
@@ -75,7 +75,7 @@ def _get_vcs_version(version_cmd=[]):
     This cmd will find the most recent tag starting with 'v' on the current
     branch.
     '''
-    try:    
+    try:
         tmpbytes = subprocess.check_output(
             version_cmd,
             stderr=subprocess.STDOUT,

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,7 +11,10 @@ import lasio.las_version
 
 def test_verify_default_vcs_tool():
     result = lasio.las_version._get_vcs_version()
-    assert version_regex.match(result) 
+    if 'GITHUB_WORKFLOW' in os.environ:
+        assert result == ""
+    else:
+        assert version_regex.match(result) 
 
 def test_non_existent_vcs_tool():
     version_cmd = ["gt", "describe", "--tags", "--match", "v*"]
@@ -22,4 +25,7 @@ def test_non_existent_vcs_tool():
 def test_explicit_existent_vcs_tool():
     version_cmd = ["git", "describe", "--tags", "--match", "v*"]
     result = lasio.las_version._get_vcs_version(version_cmd)
-    assert version_regex.match(result) 
+    if 'GITHUB_WORKFLOW' in os.environ:
+        assert result == ""
+    else:
+        assert version_regex.match(result) 


### PR DESCRIPTION
#### Related Pull Request:
This change is should follow(accompany) @dhart's https://github.com/kinverarity1/lasio/pull/374 "GitHub action added for automatic testing " Pull Request.  

#### Description
This change checks to see if Lasio is in a GITHUB_WORKFLOW environment.
If it is then the repo has been cloned without tags and the version
command will return and empty string rather than a git tag version.
If in a GITHUB_WORKFLOW version tests will assert the version string is an empty string.

#### GitHub Actions Results (All Pass):
https://github.com/dcslagel/lasio/actions/runs/250187251


#### Test Results:
```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 384     55    86%
lasio/las_items.py           190     31    84%
lasio/las_version.py          50     10    80%
lasio/reader.py              446     84    81%
lasio/writer.py              168      9    95%
----------------------------------------------
TOTAL                       1418    255    82%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
