### PR TITLE
Issue #363: correctly understand units like "1000 psi"

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -962,11 +962,16 @@ def configure_metadata_patterns(line, section_name):
     # Default return value
     patterns = []
 
-    # Default regular expressions for name, unit, value and desc fields
+    # Default regular expressions for name, value and desc fields
     name_re = r"\.?(?P<name>[^.]*)\."
-    unit_re = r"(?P<unit>[^\s]*)"
     value_re = r"(?P<value>.*):"
     desc_re = r"(?P<descr>.*)"
+
+    # Default regular expression for unit field. Note that we
+    # attempt to match "1000 psi" as a special case which allows
+    # a single whitespace character, in contradiction to the LAS specification
+    # See GitHub issue #363 for details.
+    unit_re = r"(?P<unit>([0-9]+\s)?[^\s]*)"
 
     # Alternate regular expressions for special cases
     value_without_colon_delimiter_re = r"(?P<value>[^:]*)"

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -57,3 +57,11 @@ def test_pattern_arg():
     assert result["name"] == "DEPT"
     assert result["unit"] == "M"
     assert result["value"] == ""
+
+def test_unit_with_space():
+    line = "HKLA            .1000 lbf                                  :(RT)"
+    result = read_header_line(line, section_name="Parameter")
+    assert result["name"] == "HKLA"
+    assert result["unit"] == "1000 lbf"
+    assert result["value"] == ""
+    assert result["descr"] == "(RT)"


### PR DESCRIPTION
See issue #363 for details.

Previously units in LAS files like "1000 psi" were parsed as unit "1000" and value "psi". This change tweaks the default unit regular expression to capture the special case where a numeric string such as 1000 precedes another string by a single whitespace character, resulting in the unit being parsed as "1000 psi".

It also adds the regression test `test_unit_with_space()` in `test_read_header_line.py`.