### PR TITLE
Add remove_data_line_filter to skip comment lines in the data section

### DIFF
--- a/docs/source/data-section.rst
+++ b/docs/source/data-section.rst
@@ -1,6 +1,14 @@
 Data section
 ============
 
+Ignoring commented-out lines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes data sections have comment line inside them. By default lasio will ignore
+any lines starting with the "#" character within the data section. You can
+control this using the ``remove_data_line_filter='#'`` argument to
+:meth:`lasio.LASFile.read`.
+
 Handling errors
 ~~~~~~~~~~~~~~~
 

--- a/docs/source/lasio.rst
+++ b/docs/source/lasio.rst
@@ -13,12 +13,7 @@ Reading LAS files
 .. automethod:: lasio.LASFile.match_raw_section
 .. autofunction:: lasio.reader.read_data_section_iterative
 .. autofunction:: lasio.reader.get_substitutions
-.. autofunction:: lasio.reader.parse_header_section
 .. autoclass:: lasio.reader.SectionParser
-.. autoclass:: lasio.reader.SectionParser.__call__
-.. autoclass:: lasio.reader.SectionParser.num
-.. autoclass:: lasio.reader.SectionParser.metadata
-.. autoclass:: lasio.reader.SectionParser.curves
 .. autofunction:: lasio.reader.read_header_line
 .. autoclass:: lasio.HeaderItem
 .. automethod:: lasio.HeaderItem.set_session_mnemonic_only

--- a/tests/examples/skip_data_section_comments.las
+++ b/tests/examples/skip_data_section_comments.las
@@ -1,0 +1,32 @@
+~VERSION INFORMATION
+ VERS.                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
+ WRAP.                  NO:   ONE LINE PER DEPTH STEP
+~WELL INFORMATION BLOCK
+ STRT.M        1670.000000:
+ STOP.M        1660.000000:
+ STEP.M            -0.1250:
+ NULL.           -999.2500:
+ COMP.             COMPANY:   # ANY OIL COMPANY LTD.
+ WELL.                WELL:   ANY ET AL OIL WELL #12
+ FLD .               FIELD:   EDAM
+ LOC .            LOCATION:   A9-16-49-20W3M
+ PROV.            PROVINCE:   SASKATCHEWAN
+ SRVC.     SERVICE COMPANY:   ANY LOGGING COMPANY LTD.
+ DATE.            LOG DATE:   25-DEC-1988
+ UWI .      UNIQUE WELL ID:   100091604920W300
+~CURVE INFORMATION
+ ETIM.M                      :  1  DEPTH
+ BSG1  .US/M                 :  2  SONIC TRANSIT TIME
+ BQP1.K/M3                   :  3  BULK DENSITY
+ POMS.V/V                    :  4   NEUTRON POROSITY
+ POPV.OHMM                   :  5  RXO RESISTIVITY
+ HMS1.OHMM                   :  6  SHALLOW RESISTIVITY
+~PARAMETER INFORMATION
+~Other
+~ASCII Test Data
+#   ETIM    BSG1    BQP1    POMS    POPV    HMS1
+#--------------------------------------------------------
+      0.300   2355.765    2343.880       0.000       0.000       0.000
+      0.400   2355.765    2343.880       0.000       0.000       0.000
+      0.500   2355.765    2343.880       0.000       0.000       0.000
+      0.600   2355.765    2343.880       0.000       0.000       0.000

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -289,7 +289,7 @@ def test_comma_decimal_mark_params():
 def test_missing_a_section():
     las = lasio.read(egfn("missing_a_section.las"))
     assert las.data.size == 0
-    
+
 
 def test_blank_line_in_header():
     las = lasio.read(egfn("blank_line.las"))
@@ -423,7 +423,12 @@ def test_read_cyrillic_depth_unit():
     las = lasio.read(egfn("sample_cyrillic_depth_unit.las"))
     assert las.index_unit == "M"
 
+
 def test_section_parser_num_except_pass():
     sp = lasio.reader.SectionParser("~C")
     assert sp.num(None) == None
 
+
+def test_skip_comments_in_data_section():
+    l = lasio.read(egfn("skip_data_section_comments.las"))
+    assert (l.curves[0].data == [0.3, 0.4, 0.5, 0.6]).all()


### PR DESCRIPTION
Fixes #319

This PR adds a `remove_data_line_filter` kwarg to the `las.py:LASFile.read` method, which can take a single character as a value. Then when reading any data sections in, any lines beginning with that character will be ignored. It can also take a function as a value. The function takes a line as a single argument, and should return True if the line should be skipped, and False if not.

The default value is `'#'`, so this is a change to the default behaviour, which was to (probably) throw an error, or potentially silently reading in the line.

Also contains a new regression test and example file, and a mention in the Sphinx documentation.