### PR TITLE
Add check for pushed tag version to version tests

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,24 +8,35 @@ version_regex = re.compile(r'^\d+\.\d+')
 
 import lasio.las_version
 
-
-def test_verify_default_vcs_tool():
-    result = lasio.las_version._get_vcs_version()
-    if 'GITHUB_WORKFLOW' in os.environ:
-        assert result == ""
-    else:
-        assert version_regex.match(result) 
-
 def test_non_existent_vcs_tool():
     version_cmd = ["gt", "describe", "--tags", "--match", "v*"]
     result = lasio.las_version._get_vcs_version(version_cmd)
     assert result == ""
+
+# ------------------------------------------------------------------------------
+# Most of the time GITHUB_WORKFLOW will install the lasio repo with the
+# '--no-tag' option. In those cases tags won't be available and the resulting
+# version is expected to be an empty string.
+#
+# Occationally a release version will be pushed and in those cases
+# GITHUB_WORKFLOW will specifically make the refs/tag/<pushed-tag> available
+# and the resulting version is expected to be a regular version string.
+#
+# So we check for both of those cases when testing in GITHUB_WORKFLOW
+# environment.
+# ------------------------------------------------------------------------------
+def test_verify_default_vcs_tool():
+    result = lasio.las_version._get_vcs_version()
+    if 'GITHUB_WORKFLOW' in os.environ:
+        assert result == "" or version_regex.match(result)
+    else:
+        assert version_regex.match(result)
 
 
 def test_explicit_existent_vcs_tool():
     version_cmd = ["git", "describe", "--tags", "--match", "v*"]
     result = lasio.las_version._get_vcs_version(version_cmd)
     if 'GITHUB_WORKFLOW' in os.environ:
-        assert result == ""
+        assert result == "" or version_regex.match(result)
     else:
-        assert version_regex.match(result) 
+        assert version_regex.match(result)


### PR DESCRIPTION
#### Description:

When getting Lasio's version in GITHUB_WORK flow environment, test for
both a '--no-tag' empty string version and a pushed release tag string
version.

#### Test results (All test pass for all platforms(Linux, Mac, Windows)

regular push:
https://github.com/dcslagel/lasio/actions/runs/251590209

tag push:
https://github.com/dcslagel/lasio/actions/runs/251590303

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC