### PR TITLE
Improve las_items.py:HeaderItem.__repr__ truncation logic

### DIFF
--- a/lasio/las_items.py
+++ b/lasio/las_items.py
@@ -116,10 +116,9 @@ class HeaderItem(OrderedDict):
             'descr="%s")' % (
                 self.__class__.__name__, self.mnemonic, self.unit, self.value,
                 self.descr))
-        if len(result) > 80:
-            return result[:76] + '...)'
-        else:
-            return result
+        while len(result) > 80:
+            result = result[:-3] + result[-2:]
+        return result
 
     def _repr_pretty_(self, p, cycle):
         return p.text(self.__repr__())


### PR DESCRIPTION
Previously long descr attributes might cause `HeaderItem.__repr__` to become non-valid Python code:

    HeaderItem(mnemonic="EXAMPLE", unit="", value="", descr="This is a long desc...)

This commit changes the truncation logic to remain valid code, even if the descr contents is slightly truncated.

    HeaderItem(mnemonic="EXAMPLE", unit="", value="", descr="This is a long descri")

Not ideal, but an improvement