### PR TITLE
Update ci-tests.yml

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python CI
+name: Python CI 
 
 on: [push, pull_request]
 
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,8 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy cchardet openpyxl pandas
-        pip install pytest coverage pytest-cov codecov pathlib
+        pip install --editable ".[all]" 
+        pip install pytest>=3.6 pytest-cov coverage pathlib 
     - name: Test with pytest
       run: |
-        pytest --cov-fail-under=80 --cov-branch
+        pytest


### PR DESCRIPTION
This PR updates the GitHub Actions workflow for CI testing:

- Remove macOS - I don't think it's strictly necessary.
- Align testing commands per #374 

@dcslagel sorry if you were testing this out already!