### PR TITLE
Merge request to gh-ci-changes-1 branch: Change continuous integration to make a lasio wheel

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,5 +1,8 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# This workflow will install Python dependencies, run tests and lint with a
+# variety of Python versions
+#
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python CI 
 
@@ -22,9 +25,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install --editable ".[all]" 
-        pip install pytest>=3.6 pytest-cov coverage pathlib 
+        python -m pip install --upgrade pip setuptools wheel
+        pip install ".[all]"
+        pip install pytest>=3.6 pytest-cov coverage pathlib
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
#### Description: 

    Update github ci pip commands to use wheel
    
    - Add setuptools and wheel to `pip install --update`
    - Remove '--editable' from github ci pip install cmd
    
    This causes lasio to be packaged as a wheel package.  Then the wheel
    file is installed and tested.  Before we were running the tests on the
    editable clone of the lasio repo.

#### Tests

Tab push:
https://github.com/dcslagel/lasio/actions/runs/254618661
```
...
Created wheel for lasio: filename=lasio-0.91-py3-none-any.whl
...
Installing collected packages:...lasio-0.91...
```

Regular branch push:
https://github.com/dcslagel/lasio/actions/runs/254606703
```
...
Created wheel for lasio: filename=lasio-0.1.dev1+g4494276-py3-none-any.whl
...
Installing collected packages:..lasio-0.1.dev1+g4494276...
```

##### Notes:
Because the GitHub-Actions repo is created with --no-tags the Wheel is NOT built with the previous tag. Instead, it uses `0.1` as a default.  However, the commit number `4494276b` is the actual commit of the branch head, which is good.



Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC