### PR TITLE
Re-add try-except check around call to reader.read_data_section_iterative()

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -256,13 +256,22 @@ class LASFile(object):
                     )
 
                     file_obj.seek(k)
-                    arr = reader.read_data_section_iterative(
-                        file_obj,
-                        (first_line, last_line),
-                        regexp_subs,
-                        value_null_subs,
-                        remove_line_filter=remove_data_line_filter,
-                    )
+                    # Notes see 2d9e43c3 and e960998f for 'try' background
+                    try:
+                        arr = reader.read_data_section_iterative(
+                            file_obj,
+                            (first_line, last_line),
+                            regexp_subs,
+                            value_null_subs,
+                            remove_line_filter=remove_data_line_filter,
+                        )
+                    except KeyboardInterrupt:
+                        raise
+                    except:
+                        raise exceptions.LASDataError(
+                            traceback.format_exc()[:-1]
+                            + " in data section beginning line {}".format(i + 1)
+                        )
                     logger.debug("Read ndarray {arrshape}".format(arrshape=arr.shape))
 
                     # This is so we can check data size and use self.set_data(data, truncate=False)


### PR DESCRIPTION
#### Description:

This pull-request is a finding from reviewing read_file_contents() for removal.  It adds back a `try` check around reader.read_data_section_iterative().  This try also enable Cntrl-C via raising a `KeyboardInterrupt exception`. 
For reference, the original commits were: 2d9e43c3 and e960998f. 

I think we still want this code, but not 100% sure. :-)

#### Test Results

The test results with or without this change are the same.  There isn't test coverage for it at this time.

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 389     59    85%
lasio/las_items.py           190     31    84%
lasio/las_version.py          50     10    80%
lasio/reader.py              457     84    82%
lasio/writer.py              168      9    95%
----------------------------------------------
TOTAL                       1434    259    82%

```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC