### PR TITLE
Exclude LAS files from GitHubs Language Stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 tests/examples/* linguist-vendored
+*.las -linguist-detectable


### PR DESCRIPTION
#### Description:
This commit updates how GitHub displays Lasio's language breakout by
excluding the *.las files which get mis-identified as Lasso files.
See: https://github.com/github/linguist#detectable

#### Tests:
These are results from running gitHub-linguist on local development machine:
see:
https://github.com/github/linguist#installation

Before this branch:
```
91.13%  Lasso
4.69%   Jupyter Notebook
4.18%   Python
0.01%   Dockerfile
```

After this branch:
```
52.81%  Jupyter Notebook
47.13%  Python
0.06%   Dockerfile
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC