### PR TITLE
Parsing name and unit

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -1052,7 +1052,7 @@ def configure_metadata_patterns(line, section_name):
         if ".." in line and section_name == "Curves":
             name_re = name_with_dots_re
     else:
-        if ".." in line and section_name == "Curves":
+        if re.search(r'[^ ]\.\.', line) and section_name == "Curves":
             double_dot = line.find("..")
             desc_colon = line.rfind(":")
 

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -15,7 +15,6 @@ def test_time_str_and_colon_in_desc():
     assert result["value"] == "23:15 23-JAN-2001"
     assert result["descr"] == "Time Logger: At Bottom"
 
-
 def test_cyrillic_depth_unit():
     line = u" DEPT.метер                      :  1  DEPTH"
     result = read_header_line(line, section_name="Curves")
@@ -24,7 +23,53 @@ def test_cyrillic_depth_unit():
 def test_unit_stat_with_dot():
     line = u" TDEP  ..1IN                      :  0.1-in"
     result = read_header_line(line, section_name="Curves")
+    assert result["name"] == u"TDEP"
     assert result["unit"] == u".1IN"
+
+# Look at this one
+def test_unit_stat_with_dot_2():
+    line = u"TDEP.. 1IN :0.1-ft Frame Depth {F13.4}"
+    result = read_header_line(line, section_name="Curves")
+    assert result["name"] == u"TDEP."
+    # Expected:
+    assert result["unit"] == u"1IN"
+    # Current
+    # assert result["unit"] == u""
+
+# Look at this one
+def test_unit_stat_with_dot_3():
+    line = u"TDEP. . .1IN :0.1-ft Frame Depth {F13.4}"
+    result = read_header_line(line, section_name="Curves")
+
+    # Expected:
+    assert result["name"] == u"TDEP."
+    # Current
+    # assert result["name"] == u"TDEP"
+
+    # Expected:
+    assert result["unit"] == u".1IN"
+    # Current
+    # assert result["unit"] == u""
+
+def test_unit_stat_with_dot_4():
+    line = u"TDEP..1IN :0.1-ft Frame Depth {F13.4}"
+    result = read_header_line(line, section_name="Curves")
+    assert result["name"] == u"TDEP."
+    assert result["unit"] == u"1IN"
+
+# Look at this one
+def test_unit_stat_with_dot_5():
+    line = u"TDEP. .1IN :0.1-ft Frame Depth {F13.4}"
+    result = read_header_line(line, section_name="Curves")
+    # Expected:
+    assert result["name"] == u"TDEP."
+    # Current
+    # assert result["name"] == u"TDEP"
+
+    # Expected:
+    assert result["unit"] == u"1IN"
+    # Current
+    # assert result["unit"] == u""
 
 def test_value_field_with_num_colon():
     line = "RUN . 01: RUN NUMBER"

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -21,6 +21,10 @@ def test_cyrillic_depth_unit():
     result = read_header_line(line, section_name="Curves")
     assert result["unit"] == u"метер"
 
+def test_unit_stat_with_dot():
+    line = u" TDEP  ..1IN                      :  0.1-in"
+    result = read_header_line(line, section_name="Curves")
+    assert result["unit"] == u".1IN"
 
 def test_value_field_with_num_colon():
     line = "RUN . 01: RUN NUMBER"


### PR DESCRIPTION
#### Description:

This is a discussion/research branch related to Issue #402 and Pull-Request: #403.  

This branch includes PR #403 and adds tests (2 through 5) related to parsing the metadata name and unit fields given various scenarios of dots used to signify abbreviations, the las dot delimiter, and dot as a decimal separator in unit values.

These new tests make assumptions about the expected behavior.  Could you review them to see if the tests do describe the expected behavior and if not, explain the expected behavior?

####  Testing:
Tests 2, 3, and 5 will fail.  as follows:

line = u"TDEP.. 1IN :0.1-ft Frame Depth {F13.4}" 
```python
test_unit_stat_with_dot_2 - AssertionError: assert '' == '1IN'
```

line = u"TDEP. . .1IN :0.1-ft Frame Depth {F13.4}"
```python
test_unit_stat_with_dot_3 - AssertionError: assert 'TDEP' == 'TDEP.'
```

line = u"TDEP. .1IN :0.1-ft Frame Depth {F13.4}"
```python
test_unit_stat_with_dot_5 - AssertionError: assert 'TDEP' == 'TDEP.'
```


