### PR TITLE
Add test for timestring with colon in ~Well section

### DIFF
--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -16,6 +16,14 @@ def test_time_str_and_colon_in_desc():
     assert result["descr"] == "Time Logger: At Bottom"
 
 
+def test_time_str_and_colon_in_desc_2():
+    # https://github.com/kinverarity1/lasio/issues/419
+    line = "STRT.DateTime 2012-09-16T07:44:12-05:00 : START DEPTH"
+    result = read_header_line(line, section_name="Well")
+    assert result["value"] == "2012-09-16T07:44:12-05:00"
+    assert result["descr"] == "START DEPTH"
+
+
 def test_cyrillic_depth_unit():
     line = u" DEPT.метер                      :  1  DEPTH"
     result = read_header_line(line, section_name="Curves")

--- a/tests/test_read_header_line.py
+++ b/tests/test_read_header_line.py
@@ -22,6 +22,7 @@ def test_time_str_and_colon_in_desc_2():
     result = read_header_line(line, section_name="Well")
     assert result["value"] == "2012-09-16T07:44:12-05:00"
     assert result["descr"] == "START DEPTH"
+    assert result["unit"] == "DateTime"
 
 
 def test_cyrillic_depth_unit():


### PR DESCRIPTION
#### Description

This commit add a test case for issue #419 "Colons in date formats for STRT/STOP confuse parser"

The test case is `tests/test_read_header_line.py::test_time_str_and_colon_in_desc_2`

#### Test Notes:

This test case passes with Python 3.9.1 with Lasio 0.28. 
It properly parses the time string to the value field:
`{'name': 'STRT', 'unit': 'DateTime', 'value': '2012-09-16T07:44:12-05:00', 'descr': 'START DEPTH'}`

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC

