### PR TITLE
Read quoted strings in data section properly (Fixes #271)

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -350,6 +350,12 @@ def convert_remove_line_filter(filt):
     return filt
 
 
+def split_on_whitespace(s):
+    # return s.split() # does not handle quoted substrings (#271)
+    # return shlex.split(s) # too slow
+    return [''.join(t) for t in re.findall(r"""([^\s"']+)|"([^"]*)"|'([^']*)'""", s)]
+
+
 def inspect_data_section(file_obj, line_nos, regexp_subs, remove_line_filter="#"):
     """Determine how many columns there are in the data section.
 
@@ -384,7 +390,7 @@ def inspect_data_section(file_obj, line_nos, regexp_subs, remove_line_filter="#"
         else:
             for pattern, sub_str in regexp_subs:
                 line = re.sub(pattern, sub_str, line)
-            n_items = len(line.split())
+            n_items = len(split_on_whitespace(line))
             logger.debug(
                 "Line {}: {} items counted in '{}'".format(line_no + 1, n_items, line)
             )
@@ -445,7 +451,7 @@ def read_data_section_iterative(
                 for pattern, sub_str in regexp_subs:
                     line = re.sub(pattern, sub_str, line)
                 line = line.replace(chr(26), "")
-                for item in line.split():
+                for item in split_on_whitespace(line):
                     try:
                         yield np.float64(item)
                     except ValueError:

--- a/notebooks/Speed test.ipynb
+++ b/notebooks/Speed test.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "ordinary-adapter",
+   "execution_count": 9,
+   "id": "graduate-mathematics",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,29 +11,108 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "central-giving",
+   "metadata": {},
+   "source": [
+    "# Speed"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "tropical-essex",
+   "execution_count": 10,
+   "id": "varied-mambo",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "416 ms ± 76.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "216 ms ± 30.4 ms per loop (mean ± std. dev. of 7 runs, 15 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%timeit \n",
+    "%%timeit  -n 15\n",
     "\n",
     "lasio.examples.open(\"6038187_v1.2.las\")"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "republican-yesterday",
+   "metadata": {},
+   "source": [
+    "prior to trying to fix #217:        6038187_v1.2.las = 321 ms ± 34.8 ms per loop (mean ± std. dev. of 7 runs, 15 loops each)\n",
+    "read-quoted-strings branch:         6038187_v1.2.las = 216 ms ± 37.9 ms per loop (mean ± std. dev. of 7 runs, 15 loops each)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "romantic-ontario",
+   "metadata": {},
+   "source": [
+    "# Memory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "hollywood-lucas",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "consistent-voltage",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4192151"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "las = lasio.examples.open(\"logging_levels.las\")\n",
+    "len(pickle.dumps(las))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "musical-sacramento",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "198983"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "las = lasio.examples.open(\"6038187_v1.2.las\")\n",
+    "len(pickle.dumps(las))"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "distinct-omaha",
+   "id": "horizontal-bathroom",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/Speed test.ipynb
+++ b/notebooks/Speed test.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ordinary-adapter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lasio.examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "tropical-essex",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "416 ms ± 76.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit \n",
+    "\n",
+    "lasio.examples.open(\"6038187_v1.2.las\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "distinct-omaha",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/examples/lasio_issue_271.las
+++ b/tests/examples/lasio_issue_271.las
@@ -1,0 +1,28 @@
+~Version
+ VERS              .         2.0                           : CWLS LOG ASCII STANDARD - VERSION 2.0
+ WRAP              .         NO                            : ONE LINE PER DEPTH STEP
+ DLM               .         SPACE                         : DELIMITING CHARACTER(SPACE TAB OR COMMA)
+~Well Information
+#_______________________________________________________________________________
+#
+#PARAMETER_NAME    .UNIT     VALUE                         : DESCRIPTION
+#_______________________________________________________________________________
+STRT               .m        321.16                        : First reference value
+STOP               .m        3188.59                       : Last reference value
+STEP               .m        0                             : Step increment
+NULL               .         -9999                         : Missing value
+WELL               .         xxx                           : Well name
+~Curve Information
+#_______________________________________________________________________________
+#
+#LOGNAME           .UNIT     LOG_ID                        : DESCRIPTION
+#_______________________________________________________________________________
+MD                 .m                                      :  
+TEST               .cps
+ZONE               .unitless                               :  
+~Ascii
+321.16     100     pick_alpha
+1753.2     200     pick_beta    
+1953.5     200     "pick gamma"      
+2141.05    205     'pick delta'    
+2185.34  -9999     pick_epsilon

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -432,3 +432,8 @@ def test_section_parser_num_except_pass():
 def test_skip_comments_in_data_section():
     l = lasio.read(egfn("skip_data_section_comments.las"))
     assert (l.curves[0].data == [0.3, 0.4, 0.5, 0.6]).all()
+
+
+def test_quoted_substrings_in_data_section():
+    l = lasio.read(egfn("lasio_issue_271.las"))
+    assert (l.curves[2].data == ["pick_alpha", "pick_beta", "pick gamma", "pick delta", "pick_epsilon"]).all()


### PR DESCRIPTION
This change to the function which reads numeric data sections splits that section while respecting quoted strings. See #271. Although lasio still doesn't properly support non-numeric data sections, this is a step toward it. All tests passing on Windows.