### PR TITLE
Fix SyntaxWarning in writer.py

### DIFF
--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -224,7 +224,8 @@ def write(
                 value = (fmt % n)
         except TypeError:
             value = str(n)
-        if not l is -1:
+
+        if l != -1:
             result = value.rjust(l)
         else:
             result = value


### PR DESCRIPTION
#### Description

This commit fixes `SyntaxWarning: "is not" with a literal. Did you mean "!="?` in `lasio/writer.py`

This issue is seen when running:
pytest tests/test_write.py::test_write_empty_text_value

#### Test Notes:

The test results are the same before and after the code change:
```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 407     59    86%
lasio/las_items.py           199     31    84%
lasio/las_version.py          50     14    72%
lasio/reader.py              406     32    92%
lasio/writer.py              175     10    94%
----------------------------------------------
TOTAL                       1417    212    85%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC
