### PR TITLE
Update urllib.request to be the preferred urllib

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -93,18 +93,6 @@ def open_file(file_ref, **encoding_kwargs):
         if URL_REGEXP.match(first_line):  # it's a URL
             logger.info("Loading URL {}".format(first_line))
             try:
-                import urllib2
-
-                response = urllib2.urlopen(first_line)
-                encoding = response.headers.getparam("charset")
-
-                tmp_str = response.read()
-                tmp_list = tmp_str.splitlines()
-                new_str = "\n".join(tmp_list)
-                # file_ref = StringIO(response.read())
-                file_ref = StringIO(new_str)
-                logger.debug("Retrieved data had encoding {}".format(encoding))
-            except ImportError:
                 import urllib.request
 
                 response = urllib.request.urlopen(file_ref)
@@ -120,6 +108,19 @@ def open_file(file_ref, **encoding_kwargs):
                 # translated into '\n' before being returned to the caller.
                 file_ref = StringIO(response.read().decode(encoding), newline=None)
                 logger.debug("Retrieved data decoded via {}".format(encoding))
+            except ImportError:
+                # deprecated: was part of python 2.7 support
+                import urllib2
+
+                response = urllib2.urlopen(first_line)
+                encoding = response.headers.getparam("charset")
+
+                tmp_str = response.read()
+                tmp_list = tmp_str.splitlines()
+                new_str = "\n".join(tmp_list)
+                # file_ref = StringIO(response.read())
+                file_ref = StringIO(new_str)
+                logger.debug("Retrieved data had encoding {}".format(encoding))
         elif len(lines) > 1:  # it's LAS data as a string.
             file_ref = StringIO(file_ref)
         else:  # it must be a filename
@@ -353,7 +354,7 @@ def convert_remove_line_filter(filt):
 def split_on_whitespace(s):
     # return s.split() # does not handle quoted substrings (#271)
     # return shlex.split(s) # too slow
-    return [''.join(t) for t in re.findall(r"""([^\s"']+)|"([^"]*)"|'([^']*)'""", s)]
+    return ["".join(t) for t in re.findall(r"""([^\s"']+)|"([^"]*)"|'([^']*)'""", s)]
 
 
 def inspect_data_section(file_obj, line_nos, regexp_subs, remove_line_filter="#"):

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import traceback
+import urllib.request
 
 import numpy as np
 
@@ -92,35 +93,20 @@ def open_file(file_ref, **encoding_kwargs):
         first_line = lines[0]
         if URL_REGEXP.match(first_line):  # it's a URL
             logger.info("Loading URL {}".format(first_line))
-            try:
-                import urllib.request
 
-                response = urllib.request.urlopen(file_ref)
-                if response.headers.get_content_charset() is None:
-                    if "encoding" in encoding_kwargs:
-                        encoding = encoding_kwargs["encoding"]
-                    else:
-                        encoding = "utf-8"
+            response = urllib.request.urlopen(file_ref)
+            if response.headers.get_content_charset() is None:
+                if "encoding" in encoding_kwargs:
+                    encoding = encoding_kwargs["encoding"]
                 else:
-                    encoding = response.headers.get_content_charset()
-                # newline=None causes StringIO to use universal-newline:
-                # Lines in the input can end in '\n', '\r', or '\r\n', and these are
-                # translated into '\n' before being returned to the caller.
-                file_ref = StringIO(response.read().decode(encoding), newline=None)
-                logger.debug("Retrieved data decoded via {}".format(encoding))
-            except ImportError:
-                # deprecated: was part of python 2.7 support
-                import urllib2
-
-                response = urllib2.urlopen(first_line)
-                encoding = response.headers.getparam("charset")
-
-                tmp_str = response.read()
-                tmp_list = tmp_str.splitlines()
-                new_str = "\n".join(tmp_list)
-                # file_ref = StringIO(response.read())
-                file_ref = StringIO(new_str)
-                logger.debug("Retrieved data had encoding {}".format(encoding))
+                    encoding = "utf-8"
+            else:
+                encoding = response.headers.get_content_charset()
+            # newline=None causes StringIO to use universal-newline:
+            # Lines in the input can end in '\n', '\r', or '\r\n', and these are
+            # translated into '\n' before being returned to the caller.
+            file_ref = StringIO(response.read().decode(encoding), newline=None)
+            logger.debug("Retrieved data decoded via {}".format(encoding))
         elif len(lines) > 1:  # it's LAS data as a string.
             file_ref = StringIO(file_ref)
         else:  # it must be a filename


### PR DESCRIPTION
#### Description

This pull-request attempts to resolve the problem described in issue #426 "Have an issue with urllib2 when using the lasio package".    It changes the import order for urllib.request and urllib2 so that urllib.request is tried first.  urllib.request is recommended for python3, urllib2  is no-longer updated for python3. 

 I left urllib2 in as a fallback for python2 support even though Lasio no-longer supports python2.  Let me know if it should be removed now and I'll make the update to this pull-request.

#### Test Notes:

The test results are the same before and after the code change:

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 407     59    86%
lasio/las_items.py           199     31    84%
lasio/las_version.py          50     14    72%
lasio/reader.py              406     32    92%
lasio/writer.py              175     10    94%
----------------------------------------------
TOTAL                       1417    212    85%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC