### PR TITLE
Change null_policy to handle small non-zero values

### DIFF
--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -169,7 +169,10 @@ NULL_SUBS = {
         (re.compile(r"(-?1\.#IND)[ ]"), "NaN "),
         (re.compile(r"[ ](-?1\.#IND[0-9]*)"), " NaN"),
     ],
-    "-0.0": [(re.compile(r"(-0\.0)[ ]"), "NaN "), (re.compile(r"[ ](-0\.0)"), " NaN")],
+    "-0.0": [
+        (re.compile(r"(-0\.0)[ ]"), "NaN "),
+        (re.compile(r"[ ](-0\.00*[^1-9])"), " NaN"),
+    ],
     "numbers-only": [
         (re.compile(r"([^ 0-9.\-+]+)[ ]"), "NaN "),
         (re.compile(r"[ ]([^ 0-9.\-+]+)"), " NaN"),

--- a/tests/examples/2.0/sample_2.0-small-neg-values.las
+++ b/tests/examples/2.0/sample_2.0-small-neg-values.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450  -0.0733   0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 -0.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 -0.0    0.450  123.450  123.450  110.200  105.600

--- a/tests/test_null_policy.py
+++ b/tests/test_null_policy.py
@@ -107,3 +107,8 @@ def test_null_policy_runon_ok_1():
 def test_null_policy_runon_ok_2():
     las = read(egfn("null_policy_runon.las"), read_policy='default')
     assert las['C05'][2] == -19508.961
+
+def test_null_policy_small_non_zero_neg_nums():
+    las = read(stegfn("2.0", "sample_2.0-small-neg-values.las"), null_policy="aggressive")
+    assert las['RHOB'][0] == -0.0733
+    assert numpy.isnan(las['RHOB'][1])


### PR DESCRIPTION
#### Description:

This pull-request fixes issue: 'Incorrect parsing of null values with negative values' #427

- This change filters non-zero values after '-0.0..' for null_policy='aggressive'. Example: -0.0733
- Test, test_null_policy_small_non_zero_neg_nums is added.

#### Test results:

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 407     59    86%
lasio/las_items.py           199     31    84%
lasio/las_version.py          50     14    72%
lasio/reader.py              396     25    94%
lasio/writer.py              175     10    94%
----------------------------------------------
TOTAL                       1407    205    85%
```
--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC