### PR TITLE
Fix parsing for empty ~Other section

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -214,6 +214,8 @@ class LASFile(object):
                     line_no = first_line
                     contents = []
                     for line in file_obj:
+                        if line.startswith("~") and line_no == last_line:
+                            break
                         if line.startswith("~"):
                             continue
                         line_no += 1

--- a/tests/examples/2.0/sample_2.0_empty_other_section.las
+++ b/tests/examples/2.0/sample_2.0_empty_other_section.las
@@ -1,0 +1,45 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -437,3 +437,9 @@ def test_skip_comments_in_data_section():
 def test_quoted_substrings_in_data_section():
     l = lasio.read(egfn("lasio_issue_271.las"))
     assert (l.curves[2].data == ["pick_alpha", "pick_beta", "pick gamma", "pick delta", "pick_epsilon"]).all()
+
+
+def test_read_v2_sample_empty_other_section():
+    las = lasio.read(stegfn("2.0", "sample_2.0_empty_other_section.las"))
+    assert las.other == ""
+    assert las.data[0][0] == 1670.0


### PR DESCRIPTION
#### Description:

This change addresses "Correctly reading a LAS file with an empty `~Other`" section #417

Changes
- This change prevents ~Other parsing from reading ~ASCII data
  So if the ~Other section is empty in the las file it will be empty in
  the internal las structure.
- Test case added: test_read_v2_sample_empty_other_section

#### Test Results 

No change:

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 409     59    86%
lasio/las_items.py           199     31    84%
lasio/las_version.py          50     14    72%
lasio/reader.py              396     25    94%
lasio/writer.py              175     10    94%
----------------------------------------------
TOTAL                       1409    205    85%
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC