### PR TITLE
Adjust precision when calculating STEP on write

### DIFF
--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -108,11 +108,26 @@ def write(
     if STOP is None:
         STOP = las.index[-1]
     if STEP is None:
+        # prevents an error being thrown in the case of only a single sample being written
         if STOP != STRT:
-            # prevents an error being thrown in the case of only a single sample being written
+            # Try to keep the level of precision that the original data had.
             # Example: 0.51 -> "51" -> len("51") -> 2
             # So we'll make STEP with a fractional len of '2' after the decimal
-            fraction_len = len(str(las.index[1]).split(".")[1])
+            try:
+                fraction_len_0 = len(str(las.index[0]).split(".")[1])
+            except:
+                fraction_len_0 = 0
+
+            try:
+                fraction_len_1 = len(str(las.index[1]).split(".")[1])
+            except:
+                fraction_len_1 = 0
+
+            if fraction_len_0 >= fraction_len_1:
+                fractional_len = fraction_len_0
+            else:
+                fraction_len = fraction_len_1
+
             # Faster than np.gradient
             raw_step = las.index[1] - las.index[0]
             STEP = "{:.{flen}f}".format(raw_step, flen=fraction_len)

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -110,7 +110,12 @@ def write(
     if STEP is None:
         if STOP != STRT:
             # prevents an error being thrown in the case of only a single sample being written
-            STEP = las.index[1] - las.index[0]  # Faster than np.gradient
+            # Example: 0.51 -> "51" -> len("51") -> 2
+            # So we'll make STEP with a fractional len of '2' after the decimal
+            fraction_len = len(str(las.index[1]).split(".")[1])
+            # Faster than np.gradient
+            raw_step = las.index[1] - las.index[0]
+            STEP = "{:.{flen}f}".format(raw_step, flen=fraction_len)
 
     las.well["STRT"].value = STRT
     las.well["STOP"].value = STOP

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -665,15 +665,15 @@ def test_step_unchanged_by_write():
 
 def test_step_unchanged_by_write_2():
     testfn = "test.las"
-    dstart = 10
-    dstop = 12
-    dstep = 0.51
+    dstart = 205.283
+    dstop = 1740.1034
+    dstep = 0.1524
 
     las = lasio.las.LASFile()
 
     depths = np.arange(dstart, dstop, dstep)
     las.add_curve("DEPTH", depths, unit="m")
     las.write(testfn, version=2.0)
-    assert las.well["STEP"].value == "0.51"
+    assert las.well["STEP"].value == "0.1524"
 
     os.remove(testfn)

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -653,3 +653,27 @@ def test_write_empty_text_value():
     assert las2.well.comp.unit == ""
 
     os.remove('test.las')
+
+def test_step_unchanged_by_write():
+    las = read(egfn("2.0/sample_2.0.las"))
+    las.well["UWI"] = "123456789"
+    las.write("test.las", version=2.0)
+    assert las.well["STEP"].value == "-0.125"
+
+    os.remove("test.las")
+
+
+def test_step_unchanged_by_write_2():
+    testfn = "test.las"
+    dstart = 10
+    dstop = 12
+    dstep = 0.51
+
+    las = lasio.las.LASFile()
+
+    depths = np.arange(dstart, dstop, dstep)
+    las.add_curve("DEPTH", depths, unit="m")
+    las.write(testfn, version=2.0)
+    assert las.well["STEP"].value == "0.51"
+
+    os.remove(testfn)


### PR DESCRIPTION
#### Description:

This change addresses "lasio changes STEP: adding decimals" #404

- Use the fractional precision of the 2nd depth value as the precision
  for calculating the STEP value on las.write()
- Add test cases

#### Test Results

All tests pass with a small coverage improvement in las_items.py
```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 409     59    86%
lasio/las_items.py           199     29    85%
lasio/las_version.py          50     14    72%
lasio/reader.py              396     25    94%
lasio/writer.py              177     10    94%
----------------------------------------------
TOTAL                       1411    203    86%
```

--

Note:
There are other ways to decide the fractional precision to use, rounding, floor, ceiling, etc.  Also we could look at more than one depth value to and take the longest, (or average)..  If a another solution will be better let me know and we can make the improvements.

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC