### PR TITLE
Apply fmt when writing STEP value

### DIFF
--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -108,9 +108,10 @@ def write(
     if STOP is None:
         STOP = las.index[-1]
     if STEP is None:
+        # prevents an error being thrown in the case of only a single sample being written
         if STOP != STRT:
-            # prevents an error being thrown in the case of only a single sample being written
-            STEP = las.index[1] - las.index[0]  # Faster than np.gradient
+            raw_step = las.index[1] - las.index[0]
+            STEP = fmt % raw_step
 
     las.well["STRT"].value = STRT
     las.well["STOP"].value = STOP

--- a/tests/examples/test_write_sect_widths_12.txt
+++ b/tests/examples/test_write_sect_widths_12.txt
@@ -2,18 +2,18 @@
 VERS. 1.2 : CWLS LOG ASCII STANDARD - VERSION 1.2
 WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
-STRT   .M  1670.0 : 
-STOP   .M 1669.75 : 
-STEP   .M  -0.125 : 
-NULL   .  -999.25 : 
-COMPANY.  COMPANY : # ANY OIL COMPANY LTD.
-WELL   .     WELL : ANY ET AL OIL WELL #12
-FLD    .    FIELD : EDAM
-LOC    . LOCATION : A9-16-49-20W3M
-PROV   . PROVINCE : SASKATCHEWAN
-SRVC   .  SERVICE : The company that did this logging has a very very long name....
-DATE   . LOG DATE : 25-DEC-1988
-UWI    .  WELL ID : 100091604920W300
+STRT   .M   1670.0 : 
+STOP   .M  1669.75 : 
+STEP   .M -0.12500 : 
+NULL   .   -999.25 : 
+COMPANY.   COMPANY : # ANY OIL COMPANY LTD.
+WELL   .      WELL : ANY ET AL OIL WELL #12
+FLD    .     FIELD : EDAM
+LOC    .  LOCATION : A9-16-49-20W3M
+PROV   .  PROVINCE : SASKATCHEWAN
+SRVC   .   SERVICE : The company that did this logging has a very very long name....
+DATE   .  LOG DATE : 25-DEC-1988
+UWI    .   WELL ID : 100091604920W300
 ~Curve Information -----------------------------------------
 D.M     : 1  DEPTH
 A.US/M  : 2  SONIC TRANSIT TIME

--- a/tests/test_wrapped.py
+++ b/tests/test_wrapped.py
@@ -24,7 +24,7 @@ WRAP. YES : Multiple lines per depth step
 ~Well ------------------------------------------------------
 STRT.M                   910.0 : 
 STOP.M                   909.5 : 
-STEP.M                  -0.125 : 
+STEP.M                -0.12500 : 
 NULL.                  -999.25 : Null value
 COMP.     ANY OIL COMPANY INC. : COMPANY
 WELL.    ANY ET AL XX-XX-XX-XX : WELL
@@ -119,7 +119,7 @@ WRAP.  NO : One line per depth step
 ~Well ------------------------------------------------------
 STRT.M                   910.0 : 
 STOP.M                   909.5 : 
-STEP.M                  -0.125 : 
+STEP.M                -0.12500 : 
 NULL.                  -999.25 : Null value
 COMP.     ANY OIL COMPANY INC. : COMPANY
 WELL.    ANY ET AL XX-XX-XX-XX : WELL

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -653,3 +653,27 @@ def test_write_empty_text_value():
     assert las2.well.comp.unit == ""
 
     os.remove('test.las')
+
+def test_step_unchanged_by_write():
+    las = read(egfn("2.0/sample_2.0.las"))
+    las.well["UWI"] = "123456789"
+    las.write("test.las", version=2.0)
+    assert las.well["STEP"].value == "-0.12500"
+
+    os.remove("test.las")
+
+
+def test_step_unchanged_by_write_2():
+    testfn = "test.las"
+    dstart = 205.283
+    dstop = 1740.1034
+    dstep = 0.1524
+
+    las = lasio.las.LASFile()
+
+    depths = np.arange(dstart, dstop, dstep)
+    las.add_curve("DEPTH", depths, unit="m")
+    las.write(testfn, version=2.0)
+    assert las.well["STEP"].value == "0.15240"
+
+    os.remove(testfn)

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -46,7 +46,7 @@ WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
 STRT.M   1670.0 : START DEPTH
 STOP.M  1669.75 : STOP DEPTH
-STEP.M   -0.125 : STEP
+STEP.M -0.12500 : STEP
 NULL.   -999.25 : NULL VALUE
 COMP.       ANY : COMPANY
 WELL.   AAAAA_2 : WELL
@@ -95,7 +95,7 @@ WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
 STRT.M                                                         1670.0 : START DEPTH
 STOP.M                                                        1669.75 : STOP DEPTH
-STEP.M                                                         -0.125 : STEP
+STEP.M                                                       -0.12500 : STEP
 NULL.                                                         -999.25 : NULL VALUE
 COMP.                                            ANY OIL COMPANY INC. : COMPANY
 WELL.                                                         AAAAA_2 : WELL
@@ -150,7 +150,7 @@ WRAP.  NO : One line per depth step
 ~Well ------------------------------------------------------
 STRT.M                  1670.0 : 
 STOP.M                 1669.75 : 
-STEP.M                  -0.125 : 
+STEP.M                -0.12500 : 
 NULL.                  -999.25 : 
 COMP.   # ANY OIL COMPANY LTD. : COMPANY
 WELL.   ANY ET AL OIL WELL #12 : WELL
@@ -211,7 +211,7 @@ WRAP.  NO : One line per depth step
 ~Well ------------------------------------------------------
 STRT.M                  1670.0 : 
 STOP.M                 1669.75 : 
-STEP.M                  -0.125 : 
+STEP.M                -0.12500 : 
 NULL.                  -999.25 : 
 COMP.   # ANY OIL COMPANY LTD. : COMPANY
 WELL.   ANY ET AL OIL WELL #12 : WELL
@@ -255,7 +255,7 @@ WRAP.  NO : One line per depth step
 ~Well ------------------------------------------------------
 STRT.M                  1670.0 : 
 STOP.M                 1669.75 : 
-STEP.M                  -0.125 : 
+STEP.M                -0.12500 : 
 NULL.                  -999.25 : 
 COMP.   # ANY OIL COMPANY LTD. : COMPANY
 WELL.   ANY ET AL OIL WELL #12 : WELL
@@ -300,7 +300,7 @@ WRAP.  NO : One line per depth step
 ~Well ------------------------------------------------------
 STRT.FT                 1670.0 : 
 STOP.FT                1669.75 : 
-STEP.FT                 -0.125 : 
+STEP.FT               -0.12500 : 
 NULL.                  -999.25 : 
 COMP.   # ANY OIL COMPANY LTD. : COMPANY
 WELL.   ANY ET AL OIL WELL #12 : WELL
@@ -402,7 +402,7 @@ WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
 STRT.M                  1670.0 : 
 STOP.M                 1669.75 : 
-STEP.M                  -0.125 : 
+STEP.M                -0.12500 : 
 NULL.                  -999.25 : 
 COMP.   # ANY OIL COMPANY LTD. : COMPANY
 WELL.   ANY ET AL OIL WELL #12 : WELL
@@ -505,7 +505,7 @@ WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
 STRT.M                  1670.0 : 
 STOP.M                 1669.75 : 
-STEP.M                  -0.125 : 
+STEP.M                -0.12500 : 
 NULL.                  -999.25 : 
 COMP.   # ANY OIL COMPANY LTD. : COMPANY
 WELL.   ANY ET AL OIL WELL #12 : WELL
@@ -554,7 +554,7 @@ WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
 STRT.M                  1670.0 : 
 STOP.M                 1669.75 : 
-STEP.M                  -0.125 : 
+STEP.M                -0.12500 : 
 NULL.                  -999.25 : 
 COMP.   # ANY OIL COMPANY LTD. : COMPANY
 WELL.   ANY ET AL OIL WELL #12 : WELL
@@ -602,7 +602,7 @@ WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
 STRT.M         1670.0 : START DEPTH
 STOP.M        1669.75 : STOP DEPTH
-STEP.M         -0.125 : STEP
+STEP.M       -0.12500 : STEP
 NULL.         -999.25 : NULL VALUE
 COMP.         COMPANY : ANY OIL COMPANY INC.
 WELL.            WELL : AAAAA_2


### PR DESCRIPTION
#### Description:

This is an alternate approach to resolving "lasio changes STEP: adding decimals" #404.

This approach uses `fmt="%.5f"` as the default for writing the STEP value.  The user can override the value used for `fmt`.

#### Test Results:

The test are updated now to use ".5f" precision when writing the STEP value.

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 409     59    86%
lasio/las_items.py           199     29    85%
lasio/las_version.py          50     14    72%
lasio/reader.py              396     25    94%
lasio/writer.py              176     10    94%
----------------------------------------------
TOTAL                       1410    203    86%
Coverage XML written to file coverage.xml
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

If this solution is accepted then the other solution #431 can be closed.

Thank you,
DC
