### PR TITLE
Move strt/stop/step config to its own function

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -368,6 +368,33 @@ class LASFile(object):
                 logger.warning("Conflicting index units found: {}".format(matches))
                 self.index_unit = None
 
+    def update_start_stop_step(self, STRT=None, STOP=None, STEP=None, fmt="%.5f"):
+        """Configure or Change STRT, STOP, and STEP values
+        """
+        if STRT is None:
+            STRT = self.index[0]
+        if STOP is None:
+            STOP = self.index[-1]
+        if STEP is None:
+            # prevents an error being thrown in the case of only a single sample being written
+            if STOP != STRT:
+                raw_step = self.index[1] - self.index[0]
+                STEP = fmt % raw_step
+
+        self.well["STRT"].value = STRT
+        self.well["STOP"].value = STOP
+        self.well["STEP"].value = STEP
+
+        # Check units
+        if self.curves[0].unit:
+            unit = self.curves[0].unit
+        else:
+            unit = self.well["STRT"].unit
+        self.well["STRT"].unit = unit
+        self.well["STOP"].unit = unit
+        self.well["STEP"].unit = unit
+        self.curves[0].unit = unit
+
     def write(self, file_ref, **kwargs):
         """Write LAS file to disk.
 

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -103,29 +103,7 @@ def write(
             "VERS", "", 2.0, "CWLS log ASCII Standard -VERSION 2.0"
         )
 
-    if STRT is None:
-        STRT = las.index[0]
-    if STOP is None:
-        STOP = las.index[-1]
-    if STEP is None:
-        # prevents an error being thrown in the case of only a single sample being written
-        if STOP != STRT:
-            raw_step = las.index[1] - las.index[0]
-            STEP = fmt % raw_step
-
-    las.well["STRT"].value = STRT
-    las.well["STOP"].value = STOP
-    las.well["STEP"].value = STEP
-
-    # Check units
-    if las.curves[0].unit:
-        unit = las.curves[0].unit
-    else:
-        unit = las.well["STRT"].unit
-    las.well["STRT"].unit = unit
-    las.well["STOP"].unit = unit
-    las.well["STEP"].unit = unit
-    las.curves[0].unit = unit
+    las.update_start_stop_step()
 
     # Write each section.
     # get_formatter_function ( ** get_section_widths )


### PR DESCRIPTION
#### Description:

This is part of `Remove side-effects from write()` #268 but not the whole task.

Move strt/stop/step config/change from writer.py::write() to its own function as part of the LASFile class: `update_start_stop_step()`

For this checkin,  las.update_start_stop_step()  is included in writer.py::write() so the overall behavior is the same.

#### Test Results:

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 428     60    86%
lasio/las_items.py           199     29    85%
lasio/las_version.py          50     14    72%
lasio/reader.py              396     25    94%
lasio/writer.py              159      9    94%
----------------------------------------------
TOTAL                       1412    203    86%
Coverage XML written to file coverage.xml
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC
