### PR TITLE
Add benchmark test for the speed of reading a LAS file

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -4,7 +4,7 @@
 # For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python CI 
+name: Python CI
 
 on: [push, pull_request]
 
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install ".[all]"
-        pip install pytest>=3.6 pytest-cov coverage pathlib
+        pip install ".[test]"
     - name: Test with pytest
       run: |
         pytest

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
-TEST_REQS = ("pytest>=3.6", "pytest-cov", "coverage", "codecov")
+TEST_REQS = ("pytest>=3.6", "pytest-cov", "coverage", "codecov", "pytest-benchmark")
 
 setup(
     name="lasio",

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -19,5 +19,8 @@ stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", ve
 logger = logging.getLogger(__name__)
 
 
-def test_read_v12_sample_big():
-    l = lasio.read(stegfn("1.2", "sample_big.las"))
+def read_file():
+    las = lasio.read(stegfn("1.2", "sample_big.las"))
+
+def test_read_v12_sample_big(benchmark):
+    benchmark(read_file)


### PR DESCRIPTION
To run it you need to have [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/) installed, and run the benchmarked test using:

```
$ pytest lasio/tests/test_speed.py
```

To compare two branches, you need to run and store the benchmark from the first branch e.g. master
and then run and compare the benchmark from the second branch. e.g.

```
$ git checkout master
$ mkdir ../lasio-benchmarks
$ pytest tests/test_speed.py --benchmark-autosave --benchmark-storage ../lasio-benchmarks --benchmark-compare
```

For example this compares current `master` to an version where I added `import time; time.sleep(0.5)`:

```
----------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------
Name (time in s)                               Min               Max              Mean            StdDev            Median               IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_read_v12_sample_big (0001_d2e0ca0)     1.6540 (1.0)      1.7107 (1.0)      1.6791 (1.0)      0.0222 (1.0)      1.6724 (1.0)      0.0324 (1.0)           2;0  0.5955 (1.0)           5           1
test_read_v12_sample_big (NOW)              2.1621 (1.31)     2.2645 (1.32)     2.2033 (1.31)     0.0377 (1.70)     2.1967 (1.31)     0.0364 (1.12)          2;0  0.4539 (0.76)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```