### PR TITLE
Add data section reader which uses pandas.read_csv

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -10,6 +10,7 @@ import json
 import logging
 import re
 import sys
+import traceback
 
 # get basestring in py3
 
@@ -369,8 +370,7 @@ class LASFile(object):
                 self.index_unit = None
 
     def update_start_stop_step(self, STRT=None, STOP=None, STEP=None, fmt="%.5f"):
-        """Configure or Change STRT, STOP, and STEP values
-        """
+        """Configure or Change STRT, STOP, and STEP values"""
         if STRT is None:
             STRT = self.index[0]
         if STOP is None:

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -92,7 +92,7 @@ class LASFile(object):
         null_policy="strict",
         index_unit=None,
         remove_data_line_filter="#",
-        **kwargs,
+        **kwargs
     ):
         """Read a LAS file.
 


### PR DESCRIPTION
This PR replaces `reader.py:read_data_section_iterative` with `pd.read_csv`, essentially.

improves speed for the test file (~29,900 rows x 8 columns) from 1.65 sec to 0.73 sec.

```
--------------------------------------------------------------------------------------------------- benchmark: 2 tests ---------------------------------------------------------------------------------------------------
Name (time in ms)                                  Min                   Max                  Mean              StdDev                Median                 IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_read_v12_sample_big (NOW)                728.1707 (1.0)        986.4181 (1.0)        805.3038 (1.0)      104.4843 (4.71)       769.9727 (1.0)
    102.9696 (3.18)          1;0  1.2418 (1.0)           5           1
test_read_v12_sample_big (0001_d2e0ca0)     1,654.0345 (2.27)     1,710.7092 (1.73)     1,679.1493 (2.09)      22.1773 (1.0)      1,672.4063 (2.17)
     32.3871 (1.0)           2;0  0.5955 (0.48)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

However 21 tests are failing, mostly due to the non-application of substitutions and so on. Will need to work out a way to read these files using the normal reader...

```
FAILED tests/test_null_policy.py::test_null_policy_ERR_custom - TypeError: ufunc 'isnan' not supported for the input types, and the inputs could ...
FAILED tests/test_null_policy.py::test_null_policy_text_all_subs_ERR - TypeError: ufunc 'isnan' not supported for the input types, and the inputs...
FAILED tests/test_null_policy.py::test_null_policy_text_all_subs_null - TypeError: ufunc 'isnan' not supported for the input types, and the input...
FAILED tests/test_null_policy.py::test_null_policy_text_dashes_1 - TypeError: ufunc 'isnan' not supported for the input types, and the inputs cou...
FAILED tests/test_null_policy.py::test_null_policy_text_dashes_2 - TypeError: ufunc 'isnan' not supported for the input types, and the inputs cou...
FAILED tests/test_null_policy.py::test_null_policy_text_dashes_3 - AssertionError: assert '-2550.000' == -2550
FAILED tests/test_null_policy.py::test_null_policy_runon_replaced_1 - TypeError: ufunc 'isnan' not supported for the input types, and the inputs ...
FAILED tests/test_null_policy.py::test_null_policy_runon_replaced_2 - AssertionError: assert False
FAILED tests/test_null_policy.py::test_null_policy_runon_ok_1 - AssertionError: assert '7.330-19508.961' == 7.33
FAILED tests/test_null_policy.py::test_null_policy_runon_ok_2 - assert 10.424 == -19508.961
FAILED tests/test_null_policy.py::test_null_policy_small_non_zero_neg_nums - AssertionError: assert False
FAILED tests/test_read.py::test_read_v12_sample_wrapped - lasio.exceptions.LASDataError: Traceback (most recent call last):
FAILED tests/test_read.py::test_read_v2_sample_wrapped - lasio.exceptions.LASDataError: Traceback (most recent call last):
FAILED tests/test_read.py::test_comma_decimal_mark_data - AssertionError: assert '123,420' == 123.42
FAILED tests/test_read.py::test_missing_a_section - lasio.exceptions.LASDataError: Traceback (most recent call last):
FAILED tests/test_read.py::test_blank_line_in_header - lasio.exceptions.LASDataError: Traceback (most recent call last):
FAILED tests/test_read.py::test_skip_comments_in_data_section - AttributeError: 'bool' object has no attribute 'all'
FAILED tests/test_read.py::test_quoted_substrings_in_data_section - lasio.exceptions.LASDataError: Traceback (most recent call last):
FAILED tests/test_wrapped.py::test_wrapped - lasio.exceptions.LASDataError: Traceback (most recent call last):
FAILED tests/test_wrapped.py::test_write_wrapped - lasio.exceptions.LASDataError: Traceback (most recent call last):
FAILED tests/test_wrapped.py::test_write_unwrapped - lasio.exceptions.LASDataError: Traceback (most recent call last):
============================================ 21 failed, 214 passed, 2 skipped, 8503 warnings in 26.79s ============================================
```