### PR TITLE
On write, update step vars if curve idx changed

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -65,6 +65,8 @@ class LASFile(object):
         super(LASFile, self).__init__()
         self._text = ""
         self.index_unit = None
+        self.index_name = None
+        self.index_org = None
         default_items = defaults.get_default_items()
         self.sections = {
             "Version": default_items["Version"],
@@ -367,6 +369,10 @@ class LASFile(object):
             else:
                 logger.warning("Conflicting index units found: {}".format(matches))
                 self.index_unit = None
+
+        if len(self.curves) > 0:
+            self.index_name = self.curves[0].mnemonic
+            self.index_org = self[self.index_name].copy()
 
     def update_start_stop_step(self, STRT=None, STOP=None, STEP=None, fmt="%.5f"):
         """Configure or Change STRT, STOP, and STEP values

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -65,8 +65,7 @@ class LASFile(object):
         super(LASFile, self).__init__()
         self._text = ""
         self.index_unit = None
-        self.index_name = None
-        self.index_org = None
+        self.index_initial = None
         default_items = defaults.get_default_items()
         self.sections = {
             "Version": default_items["Version"],
@@ -371,8 +370,7 @@ class LASFile(object):
                 self.index_unit = None
 
         if len(self.curves) > 0:
-            self.index_name = self.curves[0].mnemonic
-            self.index_org = self[self.index_name].copy()
+            self.index_initial = self.index.copy()
 
     def update_start_stop_step(self, STRT=None, STOP=None, STEP=None, fmt="%.5f"):
         """Configure or Change STRT, STOP, and STEP values

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -103,7 +103,15 @@ def write(
             "VERS", "", 2.0, "CWLS log ASCII Standard -VERSION 2.0"
         )
 
-    las.update_start_stop_step()
+    # -------------------------------------------------------------------------
+    # TODO: recheck this, it hasn't been validated for the case of a new las
+    # file created by Lasio
+    # -------------------------------------------------------------------------
+    # if there is a curve index name and the index curve has changed
+    # then update the step variables
+    # -------------------------------------------------------------------------
+    if las.index_name and not (las.index_org==las[las.index_name]).all():  
+        las.update_start_stop_step()
 
     # Write each section.
     # get_formatter_function ( ** get_section_widths )

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -110,8 +110,8 @@ def write(
     # if there is a curve index name and the index curve has changed
     # then update the step variables
     # -------------------------------------------------------------------------
-    if las.index_name and not (las.index_org==las[las.index_name]).all():  
-        las.update_start_stop_step()
+    if not (las.index_initial==las.index).all():  
+        las.update_start_stop_step(STRT, STOP, STEP)
 
     # Write each section.
     # get_formatter_function ( ** get_section_widths )

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -104,13 +104,21 @@ def write(
         )
 
     # -------------------------------------------------------------------------
-    # TODO: recheck this, it hasn't been validated for the case of a new las
-    # file created by Lasio
+    # If an initial curve index was not read from a las file (las.index_initial)
+    # or the curve index has changed during processing
+    # or if the STOP value doesn't match the final index value
+    # then update the step variables before writing to a new las file object.
     # -------------------------------------------------------------------------
-    # if there is a curve index name and the index curve has changed
-    # then update the step variables
-    # -------------------------------------------------------------------------
-    if not (las.index_initial==las.index).all():  
+    index_changed = False
+    stop_is_different = False
+
+    if las.index_initial is not None:
+        index_changed = not (las.index_initial == las.index).all()
+        stop_is_different = las.index_initial[-1] != las.well.STOP.value
+    else:
+        index_changed = True
+
+    if index_changed or stop_is_different:
         las.update_start_stop_step(STRT, STOP, STEP)
 
     # Write each section.

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -501,7 +501,7 @@ WRAP.  NO : ONE LINE PER DEPTH STEP
 ~Well ------------------------------------------------------
 STRT.M                  1670.0 : START DEPTH
 STOP.M                  1670.0 : STOP DEPTH
-STEP.M                       0 : STEP
+STEP.M                     0.0 : STEP
 NULL.                  -999.25 : NULL VALUE
 COMP.     ANY OIL COMPANY INC. : COMPANY
 WELL.                  AAAAA_2 : WELL


### PR DESCRIPTION
#### Description:

This should complete Remove side-effects from write() #268.

This is a first iteration at updating the STEP variable as part of the write() process but only in the following cases:
1. an initial curve index was not read from a las file (las.index_initial)
2. or the curve index has changed during processing
3. or if the STOP value doesn't match the final index value

I am not sure if case #3 should trigger updating the step variables.  It looks like many of the test case LAS files have STOP values that don't match the final index value or the final index value - 1 STEP.   Let me know if these needs to be modified.

#### Test Results:
Python 3.9

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             13      2    85%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 431     60    86%
lasio/las_items.py           199     29    85%
lasio/las_version.py          50     14    72%
lasio/reader.py              396     25    94%
lasio/writer.py              166     10    94%
----------------------------------------------
TOTAL                       1422    204    86%
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged. 

Thank you,
DC