### PR TITLE
Drop regexp subs

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -435,9 +435,9 @@ def read_data_section_iterative(
             if remove_line_filter(line):
                 continue
             else:
-                for pattern, sub_str in regexp_subs:
-                    line = re.sub(pattern, sub_str, line)
-                line = line.replace(chr(26), "")
+                # for pattern, sub_str in regexp_subs:
+                #     line = re.sub(pattern, sub_str, line)
+                # line = line.replace(chr(26), "")
                 for item in split_on_whitespace(line):
                     try:
                         yield np.float64(item)

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -278,10 +278,10 @@ def find_sections_in_file(file_obj):
     while line:
         sline = line.strip().strip("\n")
         if sline.startswith("~"):
+            file_pos = int(file_obj.tell())
             starts.append((file_pos, line_no, sline))
             if len(starts) > 1:
                 ends.append(line_no - 1)
-        file_pos = int(file_obj.tell())
         line = file_obj.readline()
         line_no = line_no + 1
 


### PR DESCRIPTION
This PR:

- removes the unneeded `file_obj.tell()` calls from find_data_sections()
- (temporarily) removes the regexp substitutions from read_data_section_iterative()

locally shows a massive improvement in speed but I am suspicious of my laptop:

```
--------------------------------------------------------------------------------------------------- benchmark: 2 tests ---------------------------------------------------------------------------------------------------
Name (time in ms)                                  Min                   Max                  Mean              StdDev                Median                 IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_read_v12_sample_big (NOW)                434.2162 (1.0)        466.4673 (1.0)        444.4479 (1.0)       12.6889 (1.0)        440.9449 (1.0)       11.0442 (1.0)           1;1  2.2500 (1.0)           5           1
test_read_v12_sample_big (0004_1c1220f)     3,666.3573 (8.44)     4,310.5298 (9.24)     3,921.8855 (8.82)     236.9141 (18.67)    3,865.0736 (8.77)     208.8955 (18.91)         2;0  0.2550 (0.11)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Profiling results (thanks @donald-keighley):

```python
>>> cProfile.run('las = lasio.read("../lasio/tests/examples/1.2/sample_big.las")', sort='tottime')
```
```
       1159116 function calls (1156513 primitive calls) in 2.152 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       41    0.324    0.008    0.324    0.008 {built-in method _imp.create_dynamic}
      223    0.260    0.001    0.260    0.001 {method 'read' of '_io.BufferedReader' objects}
   239169    0.239    0.000    0.669    0.000 reader.py:426(items)
    30303    0.177    0.000    0.177    0.000 {method 'findall' of 're.Pattern' objects}
    41/19    0.161    0.004    0.371    0.020 {built-in method _imp.exec_dynamic}
      221    0.159    0.001    0.159    0.001 {built-in method io.open_code}
      989    0.114    0.000    0.114    0.000 {built-in method nt.stat}
      221    0.076    0.000    0.076    0.000 {built-in method marshal.loads}
    29917    0.063    0.000    0.103    0.000 reader.py:343(<listcomp>)
        1    0.044    0.044    0.713    0.713 reader.py:450(<listcomp>)
   241948    0.041    0.000    0.041    0.000 {method 'join' of 'str' objects}
    29917    0.031    0.000    0.344    0.000 reader.py:340(split_on_whitespace)
        1    0.028    0.028    0.058    0.058 reader.py:261(find_sections_in_file)
   150537    0.023    0.000    0.023    0.000 {method 'strip' of 'str' objects}
      755    0.021    0.000    0.021    0.000 {method 'sub' of 're.Pattern' objects}
    30517    0.021    0.000    0.022    0.000 {method 'format' of 'str' objects}
    29917    0.020    0.000    0.210    0.000 re.py:233(findall)
```
