### PR TITLE
Change remove_line_filter to ignore_data_comments

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -86,7 +86,7 @@ class LASFile(object):
         null_policy="strict",
         ignore_header_errors=False,
         ignore_comments=("#",),
-        ignore_data_comments='#',
+        ignore_data_comments="#",
         mnemonic_case="upper",
         index_unit=None,
         **kwargs
@@ -126,9 +126,7 @@ class LASFile(object):
         if isinstance(ignore_comments, str):
             ignore_comments = [ignore_comments]
 
-        logger.debug(
-            "Ignore header lines beginning with {}".format(ignore_comments)
-        )
+        logger.debug("Ignore header lines beginning with {}".format(ignore_comments))
         logger.debug("Ignore data lines beginning with {}".format(ignore_data_comments))
 
         # Attempt to read file

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -316,32 +316,13 @@ def determine_section_type(section_title):
         return "Header items"
 
 
-def convert_ignore_comments(comments):
-    """Convert ignore_comments to a function for checking whether a line is a comment.
-
-    Arguments:
-        comments (str, sequence of strings): strings which if they occur at the
-            beginning of a line in the LAS file, the line should be considered as
-            a comment
-
-    Returns: function which takes a string (a data section line) and returns True
-        (line is a comment) or False (line is legitimate data and should be read)
-
-    """
-    if isinstance(comments, str):
-        comments = [comments]
-
-    func = lambda line: len([True for c in comments if line.strip().startswith(c)])
-    return func
-
-
 def split_on_whitespace(s):
     # return s.split() # does not handle quoted substrings (#271)
     # return shlex.split(s) # too slow
     return ["".join(t) for t in re.findall(r"""([^\s"']+)|"([^"]*)"|'([^']*)'""", s)]
 
 
-def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_comments='#'):
+def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_comments="#"):
     """Determine how many columns there are in the data section.
 
     Arguments:


### PR DESCRIPTION
This commit removes the ability for the user to pass a function as remove_data_line_filter to LASFile.read, instead replacing it with the ability to pass:

- For the header sections, a sequence of strings (`ignore_comments`)
- For the data sections, a single character (`ignore_data_comments`)

The reason for this change is to align the behaviour of the normal (current) data section reader with the to-be-implemented numpy data section reader. The latter will only be capable of filtering out lines beginning with a single character i.e. the [comments="#" argument to np.genfromtxt](https://numpy.org/devdocs/user/basics.io.genfromtxt.html#the-comments-argument)