### PR TITLE
Reshape data array inside data section reader function

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -270,6 +270,7 @@ class LASFile(object):
                             regexp_subs,
                             value_null_subs,
                             ignore_comments=ignore_data_comments,
+                            n_columns=n_columns,
                         )
                     except KeyboardInterrupt:
                         raise
@@ -278,7 +279,11 @@ class LASFile(object):
                             traceback.format_exc()[:-1]
                             + " in data section beginning line {}".format(i + 1)
                         )
-                    logger.debug("Read ndarray {arrshape}".format(arrshape=arr.shape))
+                    logger.debug(
+                        "Read ndarray {arrshape} from data section".format(
+                            arrshape=arr.shape
+                        )
+                    )
 
                     # This is so we can check data size and use self.set_data(data, truncate=False)
                     # in cases of data.size is zero.

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -3,6 +3,7 @@ import io
 import logging
 import os
 import re
+import sys
 import traceback
 import urllib.request
 


### PR DESCRIPTION
This adds two things:

1. the argument `n_columns` to the function signature    for read_data_section_iterative (i.e. the normal data section reader) function.

2. code to (attempt) to re-shape the numpy array read by the    data section reader into a 2D array.

If the file is wrapped and therefore the number of columns is unclear (i.e. `inspect_data_section()` returns -1), then the data section reader code does not currently attempt to reshape the array.

The reason for this is so that the data section reader function can be further modified to return a 2D numpy record array with different dtypes per column.