### PR TITLE
Allow writing mnemonics in ~A line

### DIFF
--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -199,7 +199,6 @@ def write(
     lines += las.other.splitlines()
 
     logger.debug("LASFile.write ASCII section")
-    # lines.append("~ASCII ".ljust(header_width, "-"))
 
     file_object.write("\n".join(lines))
     file_object.write("\n")

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -64,7 +64,7 @@ def write(
         lhs_spacer (str): string which goes on left hand side of data
             section - by default it is `" "`.
         spacer (str): string which goes between each column of the data section
-        data_section_header (str): default "~A"
+        data_section_header (str): default "~ASCII"
         mnemonics_header (bool): write mnemonics as header at top of data section
 
     Creating an output file is not the only side-effect of this function. It

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -65,7 +65,8 @@ def write(
             section - by default it is `" "`.
         spacer (str): string which goes between each column of the data section
         data_section_header (str): default "~ASCII"
-        mnemonics_header (bool): write mnemonics as header at top of data section
+        mnemonics_header (bool): include mnemonic curve names in the
+            data_section_header at the top of data section
 
     Creating an output file is not the only side-effect of this function. It
     will also modify the STRT, STOP and STEP HeaderItems so that they correctly
@@ -247,7 +248,7 @@ def write(
             return fmt
 
     def get_left_spacing(j):
-        """Get left-hand-side spcaing for column *j*."""
+        """Get left-hand-side spacing for column *j*."""
         if j == 0:
             left_spacing = lhs_spacer
         else:
@@ -258,11 +259,11 @@ def write(
     if mnemonics_header:
         # Calculate width of numeric values from the first line,
         header_col_widths = []
-        for j in range(ncols):
-            col_fmt = get_column_fmt(j)
-            left_spacing = get_left_spacing(j)
+        for col_idx in range(ncols):
+            col_fmt = get_column_fmt(col_idx)
+            left_spacing = get_left_spacing(col_idx)
             data_value = format_data_section_line(
-                data_arr[0, j], col_fmt, spacing_chars=left_spacing
+                data_arr[0, col_idx], col_fmt, spacing_chars=left_spacing
             )
             header_col_widths.append(len(data_value))
 

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -27,6 +27,8 @@ def write(
     spacer=" ",
     data_width=79,
     header_width=60,
+    data_section_header="~ASCII",
+    mnemonics_header=False,
 ):
     """Write a LAS files.
 
@@ -62,6 +64,8 @@ def write(
         lhs_spacer (str): string which goes on left hand side of data
             section - by default it is `" "`.
         spacer (str): string which goes between each column of the data section
+        data_section_header (str): default "~A"
+        mnemonics_header (bool): write mnemonics as header at top of data section
 
     Creating an output file is not the only side-effect of this function. It
     will also modify the STRT, STOP and STEP HeaderItems so that they correctly
@@ -195,7 +199,7 @@ def write(
     lines += las.other.splitlines()
 
     logger.debug("LASFile.write ASCII section")
-    lines.append("~ASCII ".ljust(header_width, "-"))
+    # lines.append("~ASCII ".ljust(header_width, "-"))
 
     file_object.write("\n".join(lines))
     file_object.write("\n")
@@ -236,19 +240,66 @@ def write(
             result = value
         return spacing_chars + result
 
+    def get_column_fmt(j):
+        """Get format string for column *j*."""
+        if j in column_fmt:
+            return column_fmt[j]
+        else:
+            return fmt
+
+    def get_left_spacing(j):
+        """Get left-hand-side spcaing for column *j*."""
+        if j == 0:
+            left_spacing = lhs_spacer
+        else:
+            left_spacing = spacer
+        return left_spacing
+
+    # Place curve mnemonics in the "~A" line.
+    if mnemonics_header:
+        # Calculate width of numeric values from the first line,
+        header_col_widths = []
+        for j in range(ncols):
+            col_fmt = get_column_fmt(j)
+            left_spacing = get_left_spacing(j)
+            data_value = format_data_section_line(
+                data_arr[0, j], col_fmt, spacing_chars=left_spacing
+            )
+            header_col_widths.append(len(data_value))
+
+        # Construct mnemonics for header line.
+        header_values = []
+        for j, curve in enumerate(las.curves):
+            col_width = header_col_widths[j]
+            if len(curve.mnemonic) > (col_width - 1):
+                width = len(curve.mnemonic) + 1
+            else:
+                width = col_width
+            value = curve.mnemonic.rjust(width)
+            header_values.append(value)
+
+        # Add data section header prefix
+        data_section_header += " "
+        if len(header_values):
+            hv = header_values[0]
+            for k in range(len(data_section_header)):
+                if k < len(hv):
+                    if hv[0] == " ":
+                        hv = hv[1:]
+            header_values = [hv] + header_values[1:]
+
+        file_object.write(data_section_header + "".join(header_values) + "\n")
+    else:
+        file_object.write((data_section_header + " ").ljust(header_width, "-") + "\n")
+
     twrapper = textwrap.TextWrapper(width=data_width)
 
     for i in range(nrows):
         logger.debug("Writing data array row {} of {}".format(i + 1, nrows))
         depth_slice = ""
         for j in range(ncols):
-            col_fmt = fmt
-            if j in column_fmt:
-                col_fmt = column_fmt[j]
-            if j == 0:
-                left_spacing = lhs_spacer
-            else:
-                left_spacing = spacer
+            col_fmt = get_column_fmt(j)
+            left_spacing = get_left_spacing(j)
             depth_slice += format_data_section_line(
                 data_arr[i, j], col_fmt, spacing_chars=left_spacing
             )

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -780,3 +780,162 @@ API .          : API NUMBER
 ~ASCII -----------------------------------------------------
 """
     )
+
+
+def test_write_data_section_header_default():
+    # Verify default behavior
+    s = StringIO()
+    las = read(egfn("2.0/sample_2.0.las"))
+    las.write(s)
+    s.seek(0)
+    assert (
+        s.read()
+        == """~Version ---------------------------------------------------
+VERS. 2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.  NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M                  1670.0 : START DEPTH
+STOP.M                 1669.75 : STOP DEPTH
+STEP.M                  -0.125 : STEP
+NULL.                  -999.25 : NULL VALUE
+COMP.     ANY OIL COMPANY INC. : COMPANY
+WELL.                  AAAAA_2 : WELL
+FLD .                  WILDCAT : FIELD
+LOC .           12-34-12-34W5M : LOCATION
+PROV.                  ALBERTA : PROVINCE
+SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
+DATE.                13-DEC-86 : LOG DATE
+UWI .         100123401234W500 : UNIQUE WELL ID
+~Curve Information -----------------------------------------
+DEPT.M                 : 1  DEPTH
+DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V  42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM 07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM 07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM 07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM 07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .   GEL CHEM : MUD TYPE
+BHT .DEGC   35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM    200.0 : BIT SIZE
+FD  .K/M3 1000.0 : FLUID DENSITY
+MATR.       SAND : NEUTRON MATRIX
+MDEN.     2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM  0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3 1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~ASCII -----------------------------------------------------
+ 1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+"""
+    )
+
+
+def test_write_data_section_header_with_curve_names():
+    # Verify that the Curve headers are included in the ~ASCII data_header
+    s = StringIO()
+    las = read(egfn("2.0/sample_2.0.las"))
+    las.write(s, mnemonics_header=True, data_section_header="~ASCII")
+    s.seek(0)
+    assert (
+        s.read()
+        == """~Version ---------------------------------------------------
+VERS. 2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.  NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M                  1670.0 : START DEPTH
+STOP.M                 1669.75 : STOP DEPTH
+STEP.M                  -0.125 : STEP
+NULL.                  -999.25 : NULL VALUE
+COMP.     ANY OIL COMPANY INC. : COMPANY
+WELL.                  AAAAA_2 : WELL
+FLD .                  WILDCAT : FIELD
+LOC .           12-34-12-34W5M : LOCATION
+PROV.                  ALBERTA : PROVINCE
+SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
+DATE.                13-DEC-86 : LOG DATE
+UWI .         100123401234W500 : UNIQUE WELL ID
+~Curve Information -----------------------------------------
+DEPT.M                 : 1  DEPTH
+DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V  42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM 07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM 07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM 07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM 07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .   GEL CHEM : MUD TYPE
+BHT .DEGC   35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM    200.0 : BIT SIZE
+FD  .K/M3 1000.0 : FLUID DENSITY
+MATR.       SAND : NEUTRON MATRIX
+MDEN.     2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM  0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3 1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~ASCII  DEPT         DT       RHOB       NPHI       SFLU       SFLA        ILM        ILD
+ 1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+"""
+    )
+
+
+def test_write_data_section_header_renamed_with_curve_names():
+    # Verify that the Curve headers are included in the ~A data_header
+    s = StringIO()
+    las = read(egfn("2.0/sample_2.0.las"))
+    las.write(s, mnemonics_header=True, data_section_header="~A")
+    s.seek(0)
+    assert (
+        s.read()
+        == """~Version ---------------------------------------------------
+VERS. 2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.  NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M                  1670.0 : START DEPTH
+STOP.M                 1669.75 : STOP DEPTH
+STEP.M                  -0.125 : STEP
+NULL.                  -999.25 : NULL VALUE
+COMP.     ANY OIL COMPANY INC. : COMPANY
+WELL.                  AAAAA_2 : WELL
+FLD .                  WILDCAT : FIELD
+LOC .           12-34-12-34W5M : LOCATION
+PROV.                  ALBERTA : PROVINCE
+SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
+DATE.                13-DEC-86 : LOG DATE
+UWI .         100123401234W500 : UNIQUE WELL ID
+~Curve Information -----------------------------------------
+DEPT.M                 : 1  DEPTH
+DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V  42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM 07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM 07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM 07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM 07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .   GEL CHEM : MUD TYPE
+BHT .DEGC   35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM    200.0 : BIT SIZE
+FD  .K/M3 1000.0 : FLUID DENSITY
+MATR.       SAND : NEUTRON MATRIX
+MDEN.     2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM  0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3 1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~A     DEPT         DT       RHOB       NPHI       SFLU       SFLA        ILM        ILD
+ 1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+"""
+    )


### PR DESCRIPTION
Partial implementation of #375  - also ref SO question https://stackoverflow.com/questions/60329481/how-to-add-curve-header-to-output-of-las-write-with-lasio-py/66939467#66939467

Adds mnemonics_header and data_section_header keyword arguments to `writer.py:write`. The former is boolean controlling whether it occurs or not (off by default for backwards compatibility). The latter allows the prefix to be controlled e.g. "~A" vs "~ASCII".

The mnemonic headers are right-aligned based on the numeric value's column width, so that a fixed-width formatting parser can read it in. If the mnemonics are too long, then they are just placed one following the other, out of alignment.

See https://gist.github.com/kinverarity1/aaf3459c3fa3eeafe127c9011c15c835 for a demo.