### PR TITLE
Add tests for data-section-header column names

### DIFF
--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -780,3 +780,162 @@ API .          : API NUMBER
 ~ASCII -----------------------------------------------------
 """
     )
+
+
+def test_write_data_section_header_default():
+    # Verify default behavior
+    s = StringIO()
+    las = read(egfn("2.0/sample_2.0.las"))
+    las.write(s)
+    s.seek(0)
+    assert (
+        s.read()
+        == """~Version ---------------------------------------------------
+VERS. 2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.  NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M                  1670.0 : START DEPTH
+STOP.M                 1669.75 : STOP DEPTH
+STEP.M                  -0.125 : STEP
+NULL.                  -999.25 : NULL VALUE
+COMP.     ANY OIL COMPANY INC. : COMPANY
+WELL.                  AAAAA_2 : WELL
+FLD .                  WILDCAT : FIELD
+LOC .           12-34-12-34W5M : LOCATION
+PROV.                  ALBERTA : PROVINCE
+SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
+DATE.                13-DEC-86 : LOG DATE
+UWI .         100123401234W500 : UNIQUE WELL ID
+~Curve Information -----------------------------------------
+DEPT.M                 : 1  DEPTH
+DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V  42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM 07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM 07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM 07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM 07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .   GEL CHEM : MUD TYPE
+BHT .DEGC   35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM    200.0 : BIT SIZE
+FD  .K/M3 1000.0 : FLUID DENSITY
+MATR.       SAND : NEUTRON MATRIX
+MDEN.     2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM  0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3 1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~ASCII -----------------------------------------------------
+ 1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+"""
+    )
+
+
+def test_write_data_section_header_with_curve_names():
+    # Verify that the Curve headers are included in the ~ASCII data_header
+    s = StringIO()
+    las = read(egfn("2.0/sample_2.0.las"))
+    las.write(s, mnemonics_header=True, data_section_header="~ASCII")
+    s.seek(0)
+    assert (
+        s.read()
+        == """~Version ---------------------------------------------------
+VERS. 2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.  NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M                  1670.0 : START DEPTH
+STOP.M                 1669.75 : STOP DEPTH
+STEP.M                  -0.125 : STEP
+NULL.                  -999.25 : NULL VALUE
+COMP.     ANY OIL COMPANY INC. : COMPANY
+WELL.                  AAAAA_2 : WELL
+FLD .                  WILDCAT : FIELD
+LOC .           12-34-12-34W5M : LOCATION
+PROV.                  ALBERTA : PROVINCE
+SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
+DATE.                13-DEC-86 : LOG DATE
+UWI .         100123401234W500 : UNIQUE WELL ID
+~Curve Information -----------------------------------------
+DEPT.M                 : 1  DEPTH
+DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V  42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM 07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM 07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM 07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM 07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .   GEL CHEM : MUD TYPE
+BHT .DEGC   35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM    200.0 : BIT SIZE
+FD  .K/M3 1000.0 : FLUID DENSITY
+MATR.       SAND : NEUTRON MATRIX
+MDEN.     2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM  0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3 1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~ASCII  DEPT         DT       RHOB       NPHI       SFLU       SFLA        ILM        ILD
+ 1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+"""
+    )
+
+
+def test_write_data_section_header_renamed_with_curve_names():
+    # Verify that the Curve headers are included in the ~A data_header
+    s = StringIO()
+    las = read(egfn("2.0/sample_2.0.las"))
+    las.write(s, mnemonics_header=True, data_section_header="~A")
+    s.seek(0)
+    assert (
+        s.read()
+        == """~Version ---------------------------------------------------
+VERS. 2.0 : CWLS log ASCII Standard -VERSION 2.0
+WRAP.  NO : ONE LINE PER DEPTH STEP
+~Well ------------------------------------------------------
+STRT.M                  1670.0 : START DEPTH
+STOP.M                 1669.75 : STOP DEPTH
+STEP.M                  -0.125 : STEP
+NULL.                  -999.25 : NULL VALUE
+COMP.     ANY OIL COMPANY INC. : COMPANY
+WELL.                  AAAAA_2 : WELL
+FLD .                  WILDCAT : FIELD
+LOC .           12-34-12-34W5M : LOCATION
+PROV.                  ALBERTA : PROVINCE
+SRVC. ANY LOGGING COMPANY INC. : SERVICE COMPANY
+DATE.                13-DEC-86 : LOG DATE
+UWI .         100123401234W500 : UNIQUE WELL ID
+~Curve Information -----------------------------------------
+DEPT.M                 : 1  DEPTH
+DT  .US/M 60 520 32 00 : 2  SONIC TRANSIT TIME
+RHOB.K/M3 45 350 01 00 : 3  BULK DENSITY
+NPHI.V/V  42 890 00 00 : 4  NEUTRON POROSITY
+SFLU.OHMM 07 220 04 00 : 5  SHALLOW RESISTIVITY
+SFLA.OHMM 07 222 01 00 : 6  SHALLOW RESISTIVITY
+ILM .OHMM 07 120 44 00 : 7  MEDIUM RESISTIVITY
+ILD .OHMM 07 120 46 00 : 8  DEEP RESISTIVITY
+~Params ----------------------------------------------------
+MUD .   GEL CHEM : MUD TYPE
+BHT .DEGC   35.5 : BOTTOM HOLE TEMPERATURE
+BS  .MM    200.0 : BIT SIZE
+FD  .K/M3 1000.0 : FLUID DENSITY
+MATR.       SAND : NEUTRON MATRIX
+MDEN.     2710.0 : LOGGING MATRIX DENSITY
+RMF .OHMM  0.216 : MUD FILTRATE RESISTIVITY
+DFD .K/M3 1525.0 : DRILL FLUID DENSITY
+~Other -----------------------------------------------------
+Note: The logging tools became stuck at 625 metres causing the data
+between 625 metres and 615 metres to be invalid.
+~A     DEPT         DT       RHOB       NPHI       SFLU       SFLA        ILM        ILD
+ 1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+"""
+    )


### PR DESCRIPTION
#### Description:

This pull-request adds test for the data-header-line branch change.   This duplicates the examples in `data-section-header.ipynb` at https://gist.github.com/kinverarity1/aaf3459c3fa3eeafe127c9011c15c835.


```
tests/test_write.py::test_write_data_section_header_default
tests/test_write.py::test_write_data_section_header_with_curve_names
tests/test_write.py::test_write_data_section_header_renamed_with_curve_names 
```


#### The edge cased described in #375 are not covered in these tests:
- where mnemonics are missing from the ~C section, there should be the appropriate lasio-generated UNKNOWN mnemonic in the ~A header row only (not in the ~C section)
-  where duplicate mnemonics exist, the ~A header row should contain these as duplicates, NOT the lasio-generated GAMM[1], GAMM[2] etc with suffixes
-  where mnemonics are longer than the specified write fmt, the width of the column in the data section will need to be increased to cater for the increased length of the mnemonic
-  when the data section is wrapped, specifying mnemonics_header_row=True should revert to False, and a logger.warning call made to inform the user/application that this doesn't work.



