### PR TITLE
Explore np.genfromtxt in the normal parsing engine

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -413,14 +413,22 @@ def read_data_section_iterative(
 
     raw_array =  [i for i in items(file_obj, start_line_no=line_nos[0], end_line_no=line_nos[1])]
 
-    array = np.genfromtxt(
-        raw_array,
-        comments=ignore_comments,
-    )
-
-    # Wasn't able to do this with genfromtxt's missing_values and filling_values..
-    for value in value_null_subs:
-        array[array == value] = np.nan
+    if len(raw_array) == 0:
+        array = np.array([])
+    elif len(value_null_subs) > 0:
+        null_sub_str = ",".join([mynum.__str__() for mynum in value_null_subs])
+        array = np.genfromtxt(
+            raw_array,
+            comments=ignore_comments,
+            missing_values=null_sub_str,
+            usemask=True
+        ).filled(np.nan)
+    else:
+        array = np.genfromtxt(
+            raw_array,
+            comments=ignore_comments,
+            dtype=np.ndarray,
+        )
 
     logger.debug("Read {} items in data section".format(len(array)))
 


### PR DESCRIPTION
#### Description:



#### Current Speed Results:

This is about 100 ms faster on my environment.  This is less speed improvement than the pure np.genfromtxt() branch but less test fail...

```
--------------------------------------------------- benchmark: 1 tests ----------------------------------------------
Name (time in ms)                 Min       Max      Mean  StdDev    Median     IQR  Outliers     OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------
test_read_v12_sample_big     819.5102  825.2673  821.4779  2.1988  820.8553  1.4853       1;1  1.2173       5           1
---------------------------------------------------------------------------------------------------------------------
```

#### Current Test Results:

FAILED tests/test_null_policy.py::test_null_policy_ERR_strict - AssertionError: assert nan == 'ERR'
FAILED tests/test_read.py::test_read_v12_sample_wrapped - ValueError: Some errors were detected !
FAILED tests/test_read.py::test_read_v2_sample_wrapped - ValueError: Some errors were detected !
FAILED tests/test_read.py::test_data_characters_1 - AssertionError: assert nan == '00:00:00'
FAILED tests/test_read.py::test_data_characters_2 - AssertionError: assert nan == '01-Jan-20'
FAILED tests/test_read.py::test_data_characters_types - AssertionError: assert False
FAILED tests/test_read.py::test_quoted_substrings_in_data_section - ValueError: Some errors were detected !
FAILED tests/test_wrapped.py::test_wrapped - ValueError: Some errors were detected !
FAILED tests/test_wrapped.py::test_write_wrapped - ValueError: Some errors were detected !
FAILED tests/test_wrapped.py::test_write_unwrapped - ValueError: Some errors were detected !

--

I'll continue to experiment with this to see if the rest of the test failures can be resolved while still keeping the 100 ms speed improvement.

DC