### PR TITLE
Add update_curve and replace_curve_item methods to LASFile (fixes #478)

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -681,7 +681,10 @@ class LASFile(object):
             self.append_curve_item(value)
         else:
             # Assume value is an ndarray
-            self.append_curve(key, value)
+            if key in self.curves.keys():
+                self.update_curve(mnemonic=key, data=value)
+            else:
+                self.append_curve(key, value)
 
     def keys(self):
         """Return curve mnemonics."""
@@ -1048,6 +1051,32 @@ class LASFile(object):
         if ix is None:
             ix = self.curves.keys().index(mnemonic)
         self.curves.pop(ix)
+
+    def update_curve(self, mnemonic=None, ix=None, data=False, unit=False, descr=False, value=False):
+        """Update a curve.
+
+        Keyword Arguments:
+            ix (int): index of curve in LASFile.curves.
+            mnemonic (str): mnemonic of curve.
+            data (ndarray): new data array (False if no update desired)
+            unit (str): new value for unit (False if no update desired)
+            descr (str): new description (False if no update desired)
+            value (str/int/float etc): new value (False if no update desired)
+
+        The index takes precedence over the mnemonic.
+
+        """
+        if ix is None:
+            ix = self.curves.keys().index(mnemonic)
+        curve = self.curves[ix]
+        if data is not False:
+            curve.data = data
+        if unit is not False:
+            curve.unit = unit
+        if descr is not False:
+            curve.descr = descr
+        if value is not False:
+            curve.value = value
 
     @property
     def json(self):

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -678,7 +678,11 @@ class LASFile(object):
                         key, value.mnemonic
                     )
                 )
-            self.append_curve_item(value)
+            if key in self.curves.keys():
+                ix = self.curves.keys().index(key)
+                self.replace_curve_item(ix, value)
+            else:
+                self.append_curve_item(value)
         else:
             # Assume value is an ndarray
             if key in self.curves.keys():
@@ -1001,6 +1005,18 @@ class LASFile(object):
         """
         assert isinstance(curve_item, CurveItem)
         self.curves.insert(ix, curve_item)
+
+    
+    def replace_curve_item(self, ix, curve_item):
+        """Replace a CurveItem.
+
+        Args:
+            ix (int): position to insert CurveItem i.e. 0 for start
+            curve_item (lasio.CurveItem)
+
+        """
+        self.delete_curve(ix=ix)
+        self.insert_curve_item(ix, curve_item)
 
     def add_curve(self, *args, **kwargs):
         """Deprecated. Use append_curve() or insert_curve() instead."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,9 +91,17 @@ def test_data_attr():
     # the .all() method assumes these are numpy ndarrays; that should be the case.
     assert (las.data == np.asarray([[1, 4, 7], [2, 5, 8], [3, 6, 9]])).all()
 
-def test_replace_curve():
+def test_update_curve():
     las = lasio.examples.open("sample.las")
     las["NPHI"] = las["NPHI"] * 100
     assert "NPHI" in las.keys()
     assert not "NPHI:1" in las.keys()
     assert not "NPHI:2" in las.keys()
+
+def test_replace_curve():
+    las = lasio.examples.open("sample.las")
+    las["NPHI"] = lasio.CurveItem("NPHI", "%", "Porosity", data=las["NPHI"] * 100)
+    assert "NPHI" in las.keys()
+    assert not "NPHI:1" in las.keys()
+    assert not "NPHI:2" in las.keys()
+    

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import lasio
+import lasio.examples
 from lasio import read, las
 
 import logging
@@ -89,3 +90,10 @@ def test_data_attr():
     logger.debug("las.data = {}".format(las.data))
     # the .all() method assumes these are numpy ndarrays; that should be the case.
     assert (las.data == np.asarray([[1, 4, 7], [2, 5, 8], [3, 6, 9]])).all()
+
+def test_replace_curve():
+    las = lasio.examples.open("sample.las")
+    las["NPHI"] = las["NPHI"] * 100
+    assert "NPHI" in las.keys()
+    assert not "NPHI:1" in las.keys()
+    assert not "NPHI:2" in las.keys()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,8 +100,7 @@ def test_update_curve():
 
 def test_replace_curve():
     las = lasio.examples.open("sample.las")
-    las["NPHI"] = lasio.CurveItem("NPHI", "%", "Porosity", data=las["NPHI"] * 100)
-    assert "NPHI" in las.keys()
-    assert not "NPHI:1" in las.keys()
-    assert not "NPHI:2" in las.keys()
+    las["NPHI"] = lasio.CurveItem("NPHI", "%", "Porosity", data=(las["NPHI"] * 100))
+    assert las.keys() == ["DEPT", "DT", "RHOB", "NPHI", "SFLU", "SFLA", "ILM", "ILD"]
+    assert (las["NPHI"] == [45, 45, 45]).all()
     


### PR DESCRIPTION
See #478. This PR:

- Adds `LASFile.update_curve` to allow updating of one or more CurveItem attributes from LASFile
- Adds `LASFile.replace_curve_item` to allow replacement of a CurveItem from LASFile
- Modifies `LASFile.__setitem__` so that the behavior is more natural, see code session below.

```
>>> import lasio.examples
>>> las = lasio.examples.open("sample.las")
>>> las["ILD_MSM"] = 100 / las["ILD"]
>>> print(las.curves)
Mnemonic  Unit  Value  Description
--------  ----  -----  -----------
DEPT      M            1  DEPTH
DT        US/M         2  SONIC TRANSIT TIME
RHOB      K/M3         3  BULK DENSITY
NPHI      V/V          4   NEUTRON POROSITY
SFLU      OHMM         5  RXO RESISTIVITY
SFLA      OHMM         6  SHALLOW RESISTIVITY
ILM       OHMM         7  MEDIUM RESISTIVITY
ILD       OHMM         8  DEEP RESISTIVITY
ILD_MSM
>>> las["ILD_MSM"] = 1000 / las["ILD"]
>>> print(las.curves)
Mnemonic  Unit  Value  Description
--------  ----  -----  -----------
DEPT      M            1  DEPTH
DT        US/M         2  SONIC TRANSIT TIME
RHOB      K/M3         3  BULK DENSITY
NPHI      V/V          4   NEUTRON POROSITY
SFLU      OHMM         5  RXO RESISTIVITY
SFLA      OHMM         6  SHALLOW RESISTIVITY
ILM       OHMM         7  MEDIUM RESISTIVITY
ILD       OHMM         8  DEEP RESISTIVITY
ILD_MSM
>>> las["NPHI"] = lasio.CurveItem("NPHI", "%", "", "neutron porosity as %", data=(las["NPHI"] * 100))
>>> print(las.curves)
Mnemonic  Unit  Value  Description
--------  ----  -----  -----------
DEPT      M            1  DEPTH
DT        US/M         2  SONIC TRANSIT TIME
RHOB      K/M3         3  BULK DENSITY
NPHI      %            neutron porosity as %
SFLU      OHMM         5  RXO RESISTIVITY
SFLA      OHMM         6  SHALLOW RESISTIVITY
ILM       OHMM         7  MEDIUM RESISTIVITY
ILD       OHMM         8  DEEP RESISTIVITY
ILD_MSM
>>> las["NPHI"]
array([45., 45., 45.])
``` 