### PR TITLE
When excess curves defined in ~C, add null data and emit warning

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -409,8 +409,12 @@ class LASFile(object):
                     # data section.
                     for curve_idx, flag in data_assigned_to_curves.items():
                         if flag is False:
+                            logger.warning(
+                                "Curve #{:.0f} '{:s}' is defined in the ~C section "
+                                "but there is no data in ~A"
+                                .format(curve_idx, self.curves[curve_idx].mnemonic)
+                            )
                             self.curves[curve_idx].data = np.empty(curve_length) * np.nan
-                            logger.debug("Creating null data array for curve_idx {:.0f}".format(curve_idx))
 
         finally:
             if hasattr(file_obj, "close"):

--- a/tests/examples/excess_curves.las
+++ b/tests/examples/excess_curves.las
@@ -1,0 +1,28 @@
+~VERSION INFORMATION
+VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .F              19160                    :START DEPTH
+STOP    .F              19160.5                  :STOP DEPTH
+STEP    .F                  0.5                  :STEP 
+NULL    .                -999.25                 :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+ ~Curve Information
+ DEPTH.F                : 1    DEPTH
+ TVD.F                  : 2    TVD
+ VS.F                   : 3    VS
+ Gamma.CPM              : 6    Gamma
+ ROP.Ft/Hr              : 5    ROP
+ TEMP.F                 : 6    Temperature (Tool)
+~A DEPTH         TVD          VS     Gamma
+ 19160.0   10415.184    8974.944    57.011
+ 19160.5   10415.190    8975.444    57.011

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -490,5 +490,5 @@ def test_excess_curves():
     assert las.curves.keys() == ["DEPTH", "TVD", "VS", "GAMMA", "ROP", "TEMP"]
     assert las.keys() == ["DEPTH", "TVD", "VS", "GAMMA", "ROP", "TEMP"]
     assert len(las["ROP"]) == 2
-    assert np.isnan(las["ROP"]).all()
-    assert las.df().columns == ["DEPTH", "TVD", "VS", "GAMMA", "ROP", "TEMP"]
+    assert numpy.isnan(las["ROP"]).all()
+    assert list(las.df().columns) == ["TVD", "VS", "GAMMA", "ROP", "TEMP"]

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -484,3 +484,11 @@ def test_index_null_issue227():
     las = lasio.examples.open("index_null.las")
     assert las['DEPT'].data[1] == 999.25
     assert numpy.isnan(las['DT'].data[0])
+
+def test_excess_curves():
+    las = lasio.examples.open("excess_curves.las")
+    assert las.curves.keys() == ["DEPTH", "TVD", "VS", "GAMMA", "ROP", "TEMP"]
+    assert las.keys() == ["DEPTH", "TVD", "VS", "GAMMA", "ROP", "TEMP"]
+    assert len(las["ROP"]) == 2
+    assert np.isnan(las["ROP"]).all()
+    assert las.df().columns == ["DEPTH", "TVD", "VS", "GAMMA", "ROP", "TEMP"]


### PR DESCRIPTION
This PR fixes #83. Changes:

In `LASFile.read`, while we are assigning data to curves, we keep track of which curve indexes have had data assigned. Afterwards we iterate over all curve indices and for any that did not have data assigned we:

- emit a `logger.warning` message
- assign a data array full of `np.nan` values