### PR TITLE
Detect and raise IOError exception for LiDAR files (fixes #472)

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -169,6 +169,12 @@ class LASFile(object):
         try:
             file_obj, self.encoding = reader.open_file(file_ref, **kwargs)
 
+            test_lidar = file_obj.read(4)
+            if test_lidar == "LASF":
+                raise IOError("This is a LASer file (i.e. LiDAR data), not a Log ASCII Standard file")
+            else:
+                file_obj.seek(0)
+
             logger.debug(
                 "Fetching substitutions for read_policy {} and null policy {}".format(
                     read_policy, null_policy


### PR DESCRIPTION
Example:

```
>>> import lasio
>>> lasio.read(r"C:\Users\kinverarity\Downloads\MineralsOF_las (2)\MineralsOF_las\244000_6595000.las")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\devapps\kinverarity\projects\lasio\lasio\__init__.py", line 34, in read
    return LASFile(file_ref, **kwargs)
  File "C:\devapps\kinverarity\projects\lasio\lasio\las.py", line 80, in __init__
    self.read(file_ref, **read_kwargs)
  File "C:\devapps\kinverarity\projects\lasio\lasio\las.py", line 174, in read
    raise IOError("This is a LASer file (i.e. LiDAR data), not a Log ASCII Standard file")
OSError: This is a LASer file (i.e. LiDAR data), not a Log ASCII Standard file
```