### PR TITLE
Parse comma-delimited ~ASCII sections #265

### DIFF
--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -95,7 +95,8 @@ DEPTH_UNITS = {
 }
 
 READ_POLICIES = {
-    "default": ["comma-decimal-mark", "run-on(-)", "run-on(.)", "run-on(NaN.)"]
+    "default": ["comma-decimal-mark", "run-on(-)", "run-on(.)", "run-on(NaN.)"],
+    "comma-delimiter": ["run-on(-)", "run-on(.)", "run-on(NaN.)"]
 }
 
 READ_SUBS = {

--- a/tests/test_read_30.py
+++ b/tests/test_read_30.py
@@ -20,14 +20,25 @@ def test_read_v30_sample():
     assert las.version[0].mnemonic == "VERS"
     assert las.version[0].value == 3.0
     assert las.version[0].descr == "CWLS LOG ASCII STANDARD -VERSION 3.0"
+    assert len(las.data) == 3
+    assert len(las.data[0]) == 15
+    assert las.data[2][8] == '2850000000000.0'
+    assert las.data[2][9] == 'LOST INTERVAL   '
 
 
-def test_read_v30_sample_v20_sections_are_empty():
+def test_read_v30_sample_standard_sections():
     """
+    Verify 'Curves' does read '~Log_Definition'
     Verify 'Curves' doesn't read 'Core_*' sections
+    Verity 'Parameter' does read '~Log_Parameter'
     Verify 'Parameter' doesn't read 'Performations_*' sections
+    
     """
     las = lasio.read(stegfn("3.0", "sample_3.0.las"))
-    assert not las.sections["Curves"]
-    assert not las.sections["Parameter"]
+    assert las.curves.DEPT.unit == "M"
+    # ~Log_Definition, a LAS3.0 equivalent of ~Curves has its data installed in Curves.
+    assert las.sections["Curves"].DEPT.unit == "M"
+    # ~Log_Parameter, a LAS3.0 equivalent of ~Parameter has its data installed in Parameter.
+    assert "Log_Parameter" not in las.sections.keys()
+    assert len(las.sections["Parameter"]) == 71
     assert las.sections["Perforations_Definition"][0].mnemonic == "PERFT:1"


### PR DESCRIPTION
#### Description: 

Parse comma-delimited ~ASCII sections #265.  This is primarily for parsing the data section of LAS-3.0 files. It should work for LAS-3.0 files using the standard Curves, Parameter, and ASCII sections and for LAS-3.0 files using the Log_Definition, Log_Parameter and Log_Data sections.

#### Change Details:

- Add define_line_splitter(). It will configure a line_splitter()
  function based on the identified data delimiter. This works for
  the normal engine. The numpy engine still needs work
- Add comma-delimiter regexp list to defaults.py::READ_POLICIES
- Add provisional_delimiter variable to hold the identifed delimiter
- Move the call to reader.get_substitutions() to after
  provisional_delimter is fully defined.
- Load the las3_data_section_indices as data_section_indicies if
  after initial scan of the las file the original data_section_inidices
  is empty and las3_data_section_indicies is populated
- Add the line_splitter func as a parameter when calling
  reader.read_data_section_iterative_normal_engine()
- Add logic conditional to associate the ~Log_* sections with the standard equivalent sections.

#### Notes:

- This change works with the normal parsing engine. 

I left these changes out of this specific pull-request. They can be implemented in future pull-requests
- Making the update for the "Numpy" parsing engine .
- Add a parameter enabling the user to specify which Data Delimiter to parse the data with.


#### Test-Results

All tests pass.
One of the LAS-3.0 tests is updated to reflect that the change will store a LAS-3.0 `~Log_Definition` sections data in Lasio's `Curve` section and the LAS-3.0's `~Log_Parameter` section in Lasio's `Parameter` section.

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             28      6    79%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 503     72    86%
lasio/las_items.py           199     29    85%
lasio/las_version.py          50     14    72%
lasio/reader.py              463     28    94%
lasio/writer.py              200     10    95%
----------------------------------------------
TOTAL                       1610    223    86%
```

--
Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC

