### PR TITLE
Add initial CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,6 +6,8 @@ authors:
   - family-names: Inverarity
     given-names: Kent
     orcid: https://orcid.org/0000-0002-5902-2007
+  - name: "Lasio contributors"
+    website: "https://lasio.readthedocs.io/en/latest/contributing.html"
 repository-code: "https://github.com/kinverarity1/lasio"
 version: 0.29
 url: https://github.com/kinverarity1/lasio/releases/tag/v0.29

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+message: Please cite this software using these metadata.
+title: Lasio
+abstract: Read and write Log ASCII Standard files with Python.
+authors:
+  - family-names: Inverarity
+    given-names: Kent
+    orcid: https://orcid.org/0000-0002-5902-2007
+repository-code: "https://github.com/kinverarity1/lasio"
+version: 0.29
+url: https://github.com/kinverarity1/lasio/releases/tag/v0.29
+commit: d2e0ca0c70bb4d5ef0a8e0a0b6a8e5df6639b09e
+date-released: 2021-04-14
+license: MIT
+type: software
+


### PR DESCRIPTION
#### Description:

This pull-request is for Issue #486 "Adding a citation file, and maybe a DOI".  
This change adds an initial CITATION.cff file.  However, I didn't find a DOI so the file does not include a DOI.  
If a DOI is created in the future it can be added to the CITATION.cff at that time.

--
Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC