### PR TITLE
Describe default read_policies in docstring

### DIFF
--- a/docs/source/data-section.rst
+++ b/docs/source/data-section.rst
@@ -94,7 +94,7 @@ This is represented in the following way:
 Note that the actual mnemonic is not present, to avoid ambiguity about
 which curve would be expected to be returned:
 
-.. code-block:: python
+.. code-block::
 
     >>> las["SFLU"]
     Traceback (most recent call last):
@@ -128,12 +128,31 @@ any lines starting with the "#" character within the data section. You can
 control this using the ``remove_data_line_filter='#'`` argument to
 :meth:`lasio.LASFile.read`.
 
-Handling errors
-~~~~~~~~~~~~~~~
+Ignoring the data section
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lasio can ignore the data section by seeing ignore_data to true:
+  ``lasio.read(file, ignore_date=True)``
+
+This will completely skip reading the data section and the returned object will just contain the header metadata section.
+
+A quick way to see the expected column names is:
+  ``lasio.read(file, ignore_data=True).keys()``
+
+To re-run without ignore_data: 
+  ``lasio.read(file).keys()``
+
+If this returns a different set of columns then there may be a data parsing
+error.  In this case, if incorrect parsing causes lasio to create extra columns
+they will be named 'UKNOWN:1', 'UNKNOWN:2', 'UNKNOWN:<n>'...  This can usually
+be fixed by tuning lasio.read()'s read_policy or null_policy options.
+
+Handling errors with read_policy and null_policy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 lasio has a flexible way of handling "errors" in the ~ASCII data section to
 accommodate how strict or flexible you want to be. The two main tools are 
-``read_policy`` and ``null_policy``. These are optional arguments to
+``read_policy`` and ``null_policy``.  These are optional arguments to
 :meth:`lasio.LASFile.read`.  Each defaults to common options which can be
 overridden either by other pre-set options or by a list of specific options.
 These policy settings are configured in ``lasio/defaults.py``.
@@ -144,11 +163,16 @@ read_policy='default', null_policy='common')``.
 
 Examples of policy override syntax
 ----------------------------------
-``lasio.read(f, read_policy='comma-delimiter')``
-``lasio.read(f, null_policy='aggressive')``
-``lasio.read(f, read_policy='comma-delimiter', null_policy='none')``
-``lasio.read(f, read_policy=["comma-decimal-mark", "run-on(.)"])``
-``lasio.read(f, null_policy=["9999.25", "999.25", "NA", "INF", "IO", "IND"])``
+Change only read_policy with one of the builtin policy sets:
+  ``lasio.read(f, read_policy='comma-delimiter')``
+Change only null_policy with one of the builtin policy sets:
+  ``lasio.read(f, null_policy='aggressive')``
+Change both read_policy and null_policy with builtin policies:
+  ``lasio.read(f, read_policy='comma-delimiter', null_policy='none')``
+Change read_policy with specific policies (found in defaults.py):
+  ``lasio.read(f, read_policy=["comma-decimal-mark", "run-on(.)"])``
+Change null_policy with your own hard-coded options:
+  ``lasio.read(f, null_policy=["9999.25", "999.25", "NA", "INF", "IO", "IND"])``
 
 
 Example errors

--- a/docs/source/data-section.rst
+++ b/docs/source/data-section.rst
@@ -132,7 +132,24 @@ Handling errors
 ~~~~~~~~~~~~~~~
 
 lasio has a flexible way of handling "errors" in the ~ASCII data section to
-accommodate how strict or flexible you want to be.
+accommodate how strict or flexible you want to be. The two main tools are 
+``read_policy`` and ``null_policy``. These are optional arguments to
+:meth:`lasio.LASFile.read`.  Each defaults to common options which can be
+overridden either by other pre-set options or by a list of specific options.
+These policy settings are configured in ``lasio/defaults.py``.
+
+By default, ``lasio.read(f)`` runs as if explicitly set to ``lasio.read(f,
+read_policy='default', null_policy='common')``.
+
+
+Examples of policy override syntax
+----------------------------------
+``lasio.read(f, read_policy='comma-delimiter')``
+``lasio.read(f, null_policy='aggressive')``
+``lasio.read(f, read_policy='comma-delimiter', null_policy='none')``
+``lasio.read(f, read_policy=["comma-decimal-mark", "run-on(.)"])``
+``lasio.read(f, null_policy=["9999.25", "999.25", "NA", "INF", "IO", "IND"])``
+
 
 Example errors
 --------------

--- a/docs/source/data-section.rst
+++ b/docs/source/data-section.rst
@@ -94,9 +94,12 @@ This is represented in the following way:
 Note that the actual mnemonic is not present, to avoid ambiguity about
 which curve would be expected to be returned:
 
-.. code-block::
+.. code-block:: python
 
     >>> las["SFLU"]
+
+.. code-block:: console
+
     Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
     File "C:\devapps\kinverarity\projects\lasio\lasio\las.py", line 661, in __getitem__
@@ -105,6 +108,8 @@ which curve would be expected to be returned:
 
 Note also that lasio remembers the original mnemonic so that on writing the file
 out, the original mnemonics are replicated:
+
+.. code-block:: python
 
     >>> import sys
     >>> las.write(sys.stdout)
@@ -131,7 +136,7 @@ control this using the ``remove_data_line_filter='#'`` argument to
 Ignoring the data section
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Lasio can ignore the data section by seeing ignore_data to true:
+Lasio can ignore the data section by setting ignore_data to true:
   ``lasio.read(file, ignore_date=True)``
 
 This will completely skip reading the data section and the returned object will just contain the header metadata section.

--- a/docs/source/header-section.rst
+++ b/docs/source/header-section.rst
@@ -376,6 +376,9 @@ This isn't a header line, and cannot be parsed as such. It results in a
 .. code-block:: python
 
     >>> las = lasio.examples.open('dodgy_param_sect.las', ignore_header_errors=False)
+
+.. code-block:: console
+
     Unable to parse line as LAS header: DEPTH     DT       RHOB     NPHI     SFLU     SFLA      ILM      ILD
     Traceback (most recent call last):
     File "C:\Users\kinve\code\lasio\lasio\reader.py", line 525, in parse_header_section

--- a/docs/source/lasio.rst
+++ b/docs/source/lasio.rst
@@ -10,7 +10,8 @@ Reading LAS files
 .. autofunction:: lasio.reader.open_with_codecs
 .. autofunction:: lasio.reader.get_encoding
 .. automethod:: lasio.LASFile.match_raw_section
-.. autofunction:: lasio.reader.read_data_section_iterative
+.. autofunction:: lasio.reader.read_data_section_iterative_normal_engine
+.. autofunction:: lasio.reader.read_data_section_iterative_numpy_engine
 .. autofunction:: lasio.reader.get_substitutions
 .. autoclass:: lasio.reader.SectionParser
 .. autofunction:: lasio.reader.read_header_line

--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -95,7 +95,8 @@ DEPTH_UNITS = {
 }
 
 READ_POLICIES = {
-    "default": ["comma-decimal-mark", "run-on(-)", "run-on(.)", "run-on(NaN.)"],
+    # Note: `run-on(NaN.)` is now covered by `run-on(.)`
+    "default": ["comma-decimal-mark", "run-on(-)", "run-on(.)"],
     "comma-delimiter": ["run-on(-)", "run-on(.)", "run-on(NaN.)"]
 }
 

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -287,6 +287,9 @@ def get_encoding(auto, raw):
 def find_sections_in_file(file_obj):
     """Find LAS sections in a file.
 
+    Arguments:
+        file_obj: file-like object open for reading at the beginning of the section
+
     Returns: a list of lists *(k, first_line_no, last_line_no, line]*.
         *file_pos* is the position in the *file_obj* in bytes,
         *first_line_no* is the first line number of the section (starting
@@ -592,6 +595,13 @@ def get_substitutions(read_policy, null_policy):
         The first list is pairs of regexp patterns and substrs, and the second
         list is just a list of floats or integers. The bool is whether or not
         'NULL' was located as a substitution.
+
+    The default READ_POLICIES are
+
+    * comma-decimal-mark : in numbers replace a comma divider with a decimal
+    * run-on(-) : separate 2 numbers that run together on the negative sign
+    * run-on(.) : replace numbers with 2 or more decimals or a NaN and a decimal with 2 NaNs
+
 
     """
     regexp_subs = []


### PR DESCRIPTION
#### Description:

This change it to address the documentation updates for #332 "Additional curves 'UNKNOWN:1' added and phantom columns made".

##### Work so far..
- Add description of the defaults.READ_POLICIES to
  reader.get_substitutions()
- remove run-on(NaN.) from defaults.READ_POLICIES['defaults'].
  It's functionality is included in run-on(.).
- Add Arguments information to reader.find_sections_in_file() docstring
- Expand the discussion in data_section.rst on handling run-on errors

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC


