### PR TITLE
Add LAS version 2.1 to defaults plus test

### DIFF
--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -78,6 +78,14 @@ ORDER_DEFINITIONS = {
             ("Parameter", ["value:descr"]),
         ]
     ),
+    2.1: OrderedDict(
+        [
+            ("Version", ["value:descr"]),
+            ("Well", ["value:descr"]),
+            ("Curves", ["value:descr"]),
+            ("Parameter", ["value:descr"]),
+        ]
+    ),
     3.0: OrderedDict(
         [
             ("Version", ["value:descr"]),

--- a/tests/examples/sample_2.1.las
+++ b/tests/examples/sample_2.1.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.1 :   CWLS LOG ASCII STANDARD -VERSION 2.1
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1669.7500                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -52,6 +52,8 @@ def test_read_v2_sample_minimal():
 def test_read_v2_sample_wrapped():
     l = lasio.read(stegfn("2.0", "sample_2.0_wrapped.las"))
 
+def test_read_v2_1_sample():
+    l = lasio.read(egfn("sample_2.1.las"))
 
 def test_dodgy_param_sect():
     with pytest.raises(lasio.exceptions.LASHeaderError):


### PR DESCRIPTION
#### Description:

This is a potential fix for: LAS 2.1 reading error #490.

This solution adds 2.1 as a separate entry to defaults.ORDER_DEFINITION.  Although this duplicates the 2.0 entry it is  efficient to read and understand.  If the try..except solution from  2d89ec4 on Aug 1, 2015 is preferred let me know and I'll make the change.

In addition a test is added.  I didn't have a genuine las 2.1 file available so I made a modified version of sample_v2.las as sample_v2_1.las  and changed the VERS string to 2.1 in the copy. 

#### Test results:

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             28      6    79%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 503     72    86%
lasio/las_items.py           199     29    85%
lasio/las_version.py          50     14    72%
lasio/reader.py              463     28    94%
lasio/writer.py              200     10    95%
----------------------------------------------
TOTAL                       1610    223    86%


--
Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC

