### PR TITLE
Resolve error in Sphinx docs

### DIFF
--- a/docs/source/header-section.rst
+++ b/docs/source/header-section.rst
@@ -289,7 +289,7 @@ Lines with colons in the mnemonic and description
 Colons are used as a delimiter, but colons can also occur inside the unit, value, and
 description fields in a LAS file header. Take this line as an example:
 
-.. code-block::
+.. code-block:: none
 
     TIML.hh:mm 23:15 23-JAN-2001:   Time Logger: At Bottom
 


### PR DESCRIPTION
See section header "Lines with colons in the mnemonic and description"

![image](https://user-images.githubusercontent.com/4525931/140676440-bde836e3-a632-46b7-b788-007d7e3d77a1.png)
