### PR TITLE
Fix missing docs example for "Mnemonics which contain a period"

### DIFF
--- a/docs/source/header-section.rst
+++ b/docs/source/header-section.rst
@@ -339,7 +339,7 @@ Mnemonics which contain a period
 As with other LAS file parsers, lasio does not parse mnemonics which contain
 a period - instead, anything after the period will be parsed as the unit:
 
-.. code-block::
+.. code-block:: none
 
     SP.COND .US/M                      :  EC at 25 deg C
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4525931/140676600-070223a6-7987-41fb-bc75-a282d1520b48.png)
