### PR TITLE
Deprecation of numpy type aliases

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -836,10 +836,10 @@ class SectionParser(object):
             pass
 
         try:
-            return np.int(x)
+            return np.int64(x)
         except:
             try:
-                x = np.float(x)
+                x = np.float64(x)
             except:
                 return default
         if np.isfinite(x):


### PR DESCRIPTION
Fixes #502 

This small mod suppresses those warnings. Per the warning, I think you could equivalently just use `int()` and `float()` too.