### PR TITLE
Docs:  update contributing setup info

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -104,6 +104,7 @@ There are some additional packages you needing for running unit/regression tests
 formatting Python code (`black`). You can install these easily by using::
 
   $ pip install --editable ".[test]"
+  $ pip install black
 
 Making changes to the code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -103,7 +103,7 @@ Making sure you have necessary development dependencies
 There are some additional packages you needing for running unit/regression tests (`pytest`) and
 formatting Python code (`black`). You can install these easily by using::
 
-  $ pip install --editable .[test]
+  $ pip install --editable ".[test]"
 
 Making changes to the code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -172,7 +172,7 @@ To run tests yourself:
 
 .. code-block::
 
-    $ pip install lasio[test]
+    $ pip install "lasio[test]"
     $ pytest
 
 .. _GitHub Actions: https://github.com/kinverarity1/lasio/actions/workflows/ci-tests.yml

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,14 @@ from setuptools import setup
 import os
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
-TEST_REQS = ("pytest>=3.6", "pytest-cov", "coverage", "codecov", "pytest-benchmark")
+TEST_REQS = (
+    "pytest>=3.6",
+    "pytest-cov",
+    "coverage",
+    "codecov",
+    "pytest-benchmark",
+    "black",
+)
 
 setup(
     name="lasio",

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,7 @@ from setuptools import setup
 import os
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
-TEST_REQS = (
-    "pytest>=3.6",
-    "pytest-cov",
-    "coverage",
-    "codecov",
-    "pytest-benchmark",
-    "black",
-)
+TEST_REQS = ("pytest>=3.6", "pytest-cov", "coverage", "codecov", "pytest-benchmark")
 
 setup(
     name="lasio",


### PR DESCRIPTION
#### Description

This is a minor update to the Contributing doc.  
- It adds double-quotes around the setup.py targets (".[tests]" and "lasio[test]")  in some pip install commands.  These are needed on some platforms otherwise the target doesn't install.
- It adds an install command for Black so that it will be in the developer's environment since it is needed as part of the process to make a Pull Request.

Note: I attempted to add Black as a required package in setup.py's 'test' tartget, but the GitHub Action failed to find a current "Black" package for (3.5, ubuntu-latest).  
 
--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC