### PR TITLE
Pull-Request to ci-changes  branch for python "3.10" and black install

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -103,7 +103,7 @@ Making sure you have necessary development dependencies
 There are some additional packages you needing for running unit/regression tests (`pytest`) and
 formatting Python code (`black`). You can install these easily by using::
 
-  $ pip install --editable .[test]
+  $ pip install --editable ".[test]"
 
 Making changes to the code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -172,7 +172,7 @@ To run tests yourself:
 
 .. code-block::
 
-    $ pip install lasio[test]
+    $ pip install "lasio[test]"
     $ pytest
 
 .. _GitHub Actions: https://github.com/kinverarity1/lasio/actions/workflows/ci-tests.yml

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,14 @@ from setuptools import setup
 import os
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
-TEST_REQS = ("pytest>=3.6", "pytest-cov", "coverage", "codecov", "pytest-benchmark")
+TEST_REQS = (
+    "pytest>=3.6",
+    "pytest-cov",
+    "coverage",
+    "codecov",
+    "pytest-benchmark",
+    "black",
+)
 
 setup(
     name="lasio",
@@ -30,13 +37,11 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering",
         "Topic :: System :: Filesystems",
         "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
#### Description: 

Add black to setup's TEST_REQS and fix ci-change for python "3.10"

  - This change includes the ci-change to remove python 3.5 from GitHub Action testing
    and add 3.9 and 3.10.
  - Fix: Add quotes around 3.10 in ci-test.yml so that 3.10 is not parsed as 3.1.
  - Now black will be installed when running 'pip install ".[test]", which
    installs packages needed for developing Lasio.
  - The install black step is removed from the contributing doc.
  - Remove python 3.2 - 2.5 from setup.py classifiers
  - Add python 3.9 and 3.10 to setup.py classifiers

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC