### PR TITLE
Tests: Add basic data column formatting test

### DIFF
--- a/docs/source/writing.rst
+++ b/docs/source/writing.rst
@@ -426,7 +426,7 @@ The default settings are:
     + 1 character for the decimal
     + 4 digits for the number to the left of the decimal
 
-        - if there are less that 4 digits, the field is padded with blank spaces
+        - if there are less than 4 digits, the field is padded with blank spaces
         - if there are more than 4 digits, the field is expanded to include all the digits
 
 - lhs_spacer defaults to 1 space. So the data is indented by one space.

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -6,6 +6,7 @@ import pytest
 import numpy as np
 
 import lasio
+import lasio.examples
 from lasio import read
 from lasio.excel import ExcelConverter
 
@@ -937,5 +938,43 @@ between 625 metres and 615 metres to be invalid.
  1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
  1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
  1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+"""
+    )
+
+
+def test_data_section_format_default():
+    s = StringIO()
+    las = lasio.examples.open("2.0/sample_2.0.las")
+    las.write(s)
+    s.seek(1665)
+    assert (
+        s.read()
+        == """~ASCII -----------------------------------------------------
+ 1670.00000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.87500  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+ 1669.75000  123.45000 2550.00000    0.45000  123.45000  123.45000  110.20000  105.60000
+"""
+    )
+
+
+def test_data_section_format_combined_parameters():
+    s = StringIO()
+    las = lasio.examples.open("2.0/sample_2.0.las")
+    empty_lhs_spacer = ""
+    comma_spacer = ","
+    no_padding = -1
+    las.write(
+        s,
+        lhs_spacer=empty_lhs_spacer,
+        spacer=comma_spacer,
+        len_numeric_field=no_padding,
+    )
+    s.seek(1665)
+    assert (
+        s.read()
+        == """~ASCII -----------------------------------------------------
+1670.00000,123.45000,2550.00000,0.45000,123.45000,123.45000,110.20000,105.60000
+1669.87500,123.45000,2550.00000,0.45000,123.45000,123.45000,110.20000,105.60000
+1669.75000,123.45000,2550.00000,0.45000,123.45000,123.45000,110.20000,105.60000
 """
     )


### PR DESCRIPTION
#### Description

This pull request adds 2 tests to cover the data formatting parameters, a test to verify the default settings and a test that uses modifications of all 3 parameters.

This is a minor improvement in test coverage from:
```
Name                       Stmts   Miss  Cover
lasio/writer.py              200     10    95%
```
to:
```
Name                       Stmts   Miss  Cover
lasio/writer.py              200      9   96%
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC