### PR TITLE
Update API Docs: Another approach: standardized API doc generation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ from pkg_resources import get_distribution
 release = get_distribution("lasio").version
 version = ".".join(release.split(".")[:2])
 
-language = None
+language = "en"
 
 exclude_patterns = []
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,8 +46,10 @@ with Python 2.7 support is version 0.26.
 .. |Research software impact| image:: http://depsy.org/api/package/pypi/lasio/badge.svg
    :target: http://depsy.org/package/python/lasio
 
+
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
+   :caption: User guide
 
    installation
    basic-example
@@ -58,9 +60,35 @@ with Python 2.7 support is version 0.26.
    exporting
    building
    encodings
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API reference
+
    lasio
+
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Other resources
+
    contributing
    changelog
 
+
+Indices and tables
+------------------
+
 * :ref:`genindex`
-* :ref:`search`
+
+
+.. toctree::
+   :caption: Project links
+   :hidden:
+
+    PyPI releases <https://pypi.org/project/lasio/>
+    Code in GitHub <https://github.com/kinverarity1/lasio>
+    Issue tracker <https://github.com/kinverarity1/lasio/issues>
+

--- a/docs/source/lasio.rst
+++ b/docs/source/lasio.rst
@@ -1,85 +1,94 @@
-Docstrings for the lasio package
-================================
+lasio package
+=============
 
-Reading LAS files
------------------
-.. autofunction:: lasio.read
-.. autoclass:: lasio.LASFile
-.. automethod:: lasio.LASFile.read
-.. autofunction:: lasio.open_file
-.. autofunction:: lasio.reader.open_with_codecs
-.. autofunction:: lasio.reader.get_encoding
-.. automethod:: lasio.LASFile.match_raw_section
-.. autofunction:: lasio.reader.read_data_section_iterative_normal_engine
-.. autofunction:: lasio.reader.read_data_section_iterative_numpy_engine
-.. autofunction:: lasio.reader.get_substitutions
-.. autoclass:: lasio.reader.SectionParser
-.. autofunction:: lasio.reader.read_header_line
-.. autoclass:: lasio.HeaderItem
-.. automethod:: lasio.HeaderItem.set_session_mnemonic_only
-.. autoclass:: lasio.CurveItem
-.. autoclass:: lasio.SectionItems
+Submodules
+----------
 
-Reading data
---------------
-.. automethod:: lasio.LASFile.__getitem__
-.. automethod:: lasio.LASFile.__setitem__
-.. automethod:: lasio.LASFile.get_curve
-.. automethod:: lasio.LASFile.keys
-.. automethod:: lasio.LASFile.values
-.. automethod:: lasio.LASFile.items
-.. automethod:: lasio.LASFile.df
-.. autoattribute:: lasio.LASFile.version
-.. autoattribute:: lasio.LASFile.well
-.. autoattribute:: lasio.LASFile.curves
-.. autoattribute:: lasio.LASFile.curvesdict
-.. autoattribute:: lasio.LASFile.params
-.. autoattribute:: lasio.LASFile.other
-.. autoattribute:: lasio.LASFile.index
-.. autoattribute:: lasio.LASFile.depth_m
-.. autoattribute:: lasio.LASFile.depth_ft
-.. autoattribute:: lasio.LASFile.data
-.. automethod:: lasio.LASFile.stack_curves
+lasio.convert_version module
+-----------------------------
 
-Reading and modifying header data
----------------------------------
-.. autoclass:: lasio.SectionItems
-    :members:
+.. automodule:: lasio.convert_version
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-Modifying data
---------------
-.. automethod:: lasio.LASFile.set_data
-.. automethod:: lasio.LASFile.set_data_from_df
-.. automethod:: lasio.LASFile.append_curve
-.. automethod:: lasio.LASFile.insert_curve
-.. automethod:: lasio.LASFile.delete_curve
-.. automethod:: lasio.LASFile.append_curve_item
-.. automethod:: lasio.LASFile.insert_curve_item
 
-Writing data out
-----------------
-.. automethod:: lasio.LASFile.write
-.. autofunction:: lasio.writer.write
-.. autofunction:: lasio.writer.get_formatter_function
-.. autofunction:: lasio.writer.get_section_order_function
-.. autofunction:: lasio.writer.get_section_widths
-.. automethod:: lasio.LASFile.to_csv
-.. automethod:: lasio.LASFile.to_excel
-.. autoclass:: lasio.excel.ExcelConverter
-.. automethod:: lasio.excel.ExcelConverter.set_las
-.. automethod:: lasio.excel.ExcelConverter.generate_workbook
-.. automethod:: lasio.excel.ExcelConverter.write
-.. automethod:: lasio.LASFile.to_json
+lasio.defaults module
+-----------------------------
 
-Custom exceptions
------------------
-.. autoclass:: lasio.exceptions.LASDataError
-.. autoclass:: lasio.exceptions.LASHeaderError
-.. autoclass:: lasio.exceptions.LASUnknownUnitError
+.. automodule:: lasio.defaults
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-Test data
----------
-.. autofunction:: lasio.examples.open
-.. autofunction:: lasio.examples.open_github_example
-.. autofunction:: lasio.examples.open_local_example
-.. autofunction:: lasio.examples.get_local_examples_path
+lasio.examples module
+-----------------------------
+
+.. automodule:: lasio.examples
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lasio.excel module
+-----------------------------
+
+.. automodule:: lasio.excel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lasio.exceptions module
+-----------------------------
+
+.. automodule:: lasio.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lasio.las module
+-----------------------------
+
+.. automodule:: lasio.las
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lasio.las_items module
+-----------------------------
+
+.. automodule:: lasio.las_items
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lasio.las_version module
+-----------------------------
+
+.. automodule:: lasio.las_version
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lasio.reader module
+-----------------------------
+
+.. automodule:: lasio.reader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+lasio.writer module
+-----------------------------
+
+.. automodule:: lasio.writer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+-----------------------------
+
+.. automodule:: lasio
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -64,7 +64,7 @@ def read(file_ref, **kwargs):
     """Read a LAS file.
 
     Note that only versions 1.2 and 2.0 of the LAS file specification
-    are currently supported.
+    are fully supported. There is partial support for reading LAS 3.0 files.
 
     Arguments:
         file_ref (file-like object, str): either a filename, an open file


### PR DESCRIPTION
#### Description:

This pull-request is a companion option to #523 "Docs: Add a few newer API functions".  This is a different approach and may not be desirable or might suggest and even better approach.  The main changes are:

- Experiment with a standardized, more generic lasio.rst.  This option replaces the topic organized lasio.rst with a generalized one that calls the same sphinx config on each of the lasio module files and documents their doc strings.  Both approaches have benefits.  
     - The original lasio.rst is organized by topic: reading las files, displaying data, writing las files, etc.  This is helpful to the user.  However, the lasio.rst needs to be manually updated to add new API calls.
     - This example lasio.rst, doesn't require manual updating. Each time the docs are generated the latest API information is used.  However, the module layout isn't as human user friendly.

- Adopt some of the organization style of welly in index.rst. Mainly add Section captions to the document layout and some project related links

--

Let me know if this change is preferred to #523,  or if #523 is preferred or if there is a hybrid approach that enables the benefits of both of #523 and this pull-request.  I think additional changes to either of these options is  needed to get the right scope of detail and organization for the API.


Thank you,
DC

-- 

