### PR TITLE
Remove deprecated functions from las.py

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -1031,10 +1031,6 @@ class LASFile(object):
         """
         return self.index_unit and (unit_code.upper() in self.index_unit.upper())
 
-    def add_curve_raw(self, mnemonic, data, unit="", descr="", value=""):
-        """Deprecated. Use append_curve_item() or insert_curve_item() instead."""
-        return self.append_curve_item(self, mnemonic, data, unit, descr, value)
-
     def append_curve_item(self, curve_item):
         """Add a CurveItem.
 
@@ -1065,10 +1061,6 @@ class LASFile(object):
         """
         self.delete_curve(ix=ix)
         self.insert_curve_item(ix, curve_item)
-
-    def add_curve(self, *args, **kwargs):
-        """Deprecated. Use append_curve() or insert_curve() instead."""
-        return self.append_curve(*args, **kwargs)
 
     def append_curve(self, mnemonic, data, unit="", descr="", value=""):
         """Add a curve.
@@ -1146,19 +1138,6 @@ class LASFile(object):
     def json(self):
         """Return object contents as a JSON string."""
         return self.to_json()
-
-    def to_json_old(self):
-        """
-        deprecated: to_json_old version=0.25.1 since=20200507 remove=20210508
-        replacement_options: to_json()
-        """
-        obj = OrderedDict()
-        for name, section in self.sections.items():
-            try:
-                obj[name] = section.json
-            except AttributeError:
-                obj[name] = json.dumps(section)
-        return json.dumps(obj)
 
     def to_json(self):
         return json.dumps(self, cls=JSONEncoder)

--- a/tests/test_sectionitems.py
+++ b/tests/test_sectionitems.py
@@ -50,14 +50,14 @@ def test_section_items_indices():
     assert sl.keys() == ["DT", "RHOB", "NPHI"]
 
 
-def test_add_curve_duplicate():
+def test_append_curve_duplicate():
     las = lasio.LASFile()
     a = np.array([1, 2, 3, 4])
     b1 = np.array([5, 9, 1, 4])
     b2 = np.array([1, 2, 3, 2])
-    las.add_curve("DEPT", a)
-    las.add_curve("B", b1, descr="b1")
-    las.add_curve("B", b2, descr="b2")
+    las.append_curve("DEPT", a)
+    las.append_curve("B", b1, descr="b1")
+    las.append_curve("B", b2, descr="b2")
     # assert l.keys == ['DEPT', 'B', 'B']
     assert [c.descr for c in las.curves] == ["", "b1", "b2"]
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -729,7 +729,7 @@ def test_step_unchanged_by_write_2():
     las = lasio.las.LASFile()
 
     depths = np.arange(dstart, dstop, dstep)
-    las.add_curve("DEPTH", depths, unit="m")
+    las.append_curve("DEPTH", depths, unit="m")
     las.write(testfn, version=2.0)
     assert las.well["STEP"].value == "0.15240"
 


### PR DESCRIPTION
#### Description: 
This pull-request removes so older and deprecated functions from las.py

Deprecated 3 years ago:
- add_curve_raw()
- add_curve()

Deprecated 2 years ago:
- to_json_old()

Tests updated:
- tests/test_sectionitems.py::test_add_curve_duplicate
  renamed: tests/test_sectionitems.py::test_append_curve_duplicate
- tests/test_write.py::test_step_unchanged_by_write_2


#### Test Results
```
---------- coverage: platform darwin, python 3.8.9-final-0 -----------
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             28      6    79%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             11      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 491     64    87%
lasio/las_items.py           220     30    86%
lasio/las_version.py          50     14    72%
lasio/reader.py              463     27    94%
lasio/writer.py              200      9    96%
----------------------------------------------
TOTAL                       1619    214    87%
```

--
Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC
