### PR TITLE
Detect hyphens in data section and adjust regexp_subs as needed

### DIFF
--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -73,12 +73,72 @@ def read(file_ref, **kwargs):
         file_ref( :term:`file-like object` or :class:`str`): either a filename,
             an open file object, or a string containing the contents of a file.
 
-    Returns:
-        a :class:`lasio.LASFile` object representing the file -- see above
+    Keyword Arguments:
+        ignore_header_errors (bool): ignore LASHeaderErrors (False by
+            default)
+        ignore_comments (sequence/str): ignore lines beginning with these
+            characters e.g. ``("#", '"')`` in header sections.
+        ignore_data_comments (str): ignore lines beginning with this
+            character in data sections only.
+        mnemonic_case (str): 'preserve': keep the case of HeaderItem mnemonics
+                             'upper': convert all HeaderItem mnemonics to uppercase
+                             'lower': convert all HeaderItem mnemonics to lowercase
+        ignore_data (bool): if True, do not read in any of the actual data,
+            just the header metadata. False by default.
+        engine (str): "normal": parse data section with normal Python reader
+            (quite slow); "numpy": parse data section with `numpy.genfromtxt` (fast).
+            By default the engine is "numpy".
+        use_normal_engine_for_wrapped (bool): if header metadata indicates that
+            the file is wrapped, always use the 'normal' engine. Default is True.
+            The only reason you should use False is if speed is a very high priority
+            and you had files with metadata that incorrectly indicates they are
+            wrapped.
+        read_policy (str or list): Apply regular expression substitutions for common errors in      
+                fixed-width formatted data sections. If you do not want any such substitutions
+                to applied, pass ``read_policy=()``.
+        null_policy (str or list): see
+            https://lasio.readthedocs.io/en/latest/data-section.html#handling-invalid-data-indicators-automatically
+        accept_regexp_sub_recommendations (bool): Accept recommendations to auto-
+            matically remove read substitutions (applied by the default read_policy)
+            which look for numeric run-on errors involving hyphens. This avoids
+            incorrect parsing of dates such as '2018-05-22' as three separate columns
+            containing '2018', '-5' and '-22'. The read substitutions are applied only
+            if the inspection code of the data section finds a hyphen in every line.
+            The only circumstance where this should be manually set to False is where
+            you have very problematic fixed-column-width data sections involving negative
+            values.
+        index_unit (str): Optionally force-set the index curve's unit to "m" or "ft"
+        dtypes ("auto", dict or list): specify the data types for each curve in the
+            ~ASCII data section. If "auto", each curve will be converted to floats if
+            possible and remain as str if not. If a dict you can specify only the
+            curve mnemonics you want to convert as a key. If a list, please specify
+            data types for each curve in order. Note that the conversion currently
+            only occurs via numpy.ndarray.astype() and therefore only a few simple
+            casts will work e.g. `int`, `float`, `str`.
+        encoding (str): character encoding to open file_ref with, using
+            :func:`io.open` (this is handled by
+            :func:`lasio.reader.open_with_codecs`)
+        encoding_errors (str): 'strict', 'replace' (default), 'ignore' - how to
+            handle errors with encodings (see
+            `this section
+            <https://docs.python.org/3/library/codecs.html#codec-base-classes>`__
+            of the standard library's :mod:`codecs` module for more information)
+            (this is handled by :func:`lasio.reader.open_with_codecs`)
+        autodetect_encoding (str or bool): default True to use
+            `chardet <https://github.com/chardet/chardet>`__/`cchardet
+            <https://github.com/PyYoshi/cChardet>`__ to detect encoding.
+            Note if set to False several common encodings will be tried but
+            chardet won't be used.
+            (this is handled by :func:`lasio.reader.open_with_codecs`)
+        autodetect_encoding_chars (int/None): number of chars to read from LAS
+            file for auto-detection of encoding.
+            (this is handled by :func:`lasio.reader.open_with_codecs`)
 
-    There are a number of optional keyword arguments that can be passed to this
-    function that control how the LAS file is opened and parsed. Any of the
-    keyword arguments from the below functions can be used here:
+    
+    Returns:
+        a :class:`lasio.LASFile` object representing the file
+
+    The documented arguments above are combined from these methods:
 
     * :func:`lasio.reader.open_with_codecs` - manage issues relate to character
       encodings

--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -93,7 +93,7 @@ def read(file_ref, **kwargs):
             The only reason you should use False is if speed is a very high priority
             and you had files with metadata that incorrectly indicates they are
             wrapped.
-        read_policy (str or list): Apply regular expression substitutions for common errors in      
+        read_policy (str or list): Apply regular expression substitutions for common errors in
                 fixed-width formatted data sections. If you do not want any such substitutions
                 to applied, pass ``read_policy=()``.
         null_policy (str or list): see
@@ -134,7 +134,7 @@ def read(file_ref, **kwargs):
             file for auto-detection of encoding.
             (this is handled by :func:`lasio.reader.open_with_codecs`)
 
-    
+
     Returns:
         a :class:`lasio.LASFile` object representing the file
 

--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -114,6 +114,8 @@ READ_SUBS = {
     "run-on(.)": [(re.compile(r"-?\d*\.\d*\.\d*|NaN[\.-]\d+"), " NaN NaN ")],
 }
 
+HYPHEN_SUBS = ['run-on(-)']
+
 NULL_POLICIES = {
     "none": [],
     "strict": ["NULL"],

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -67,7 +67,7 @@ class LASFile(object):
             The only reason you should use False is if speed is a very high priority
             and you had files with metadata that incorrectly indicates they are
             wrapped.
-        read_policy (str or list): Apply regular expression substitutions for common errors in      
+        read_policy (str or list): Apply regular expression substitutions for common errors in
                 fixed-width formatted data sections. If you do not want any such substitutions
                 to applied, pass ``read_policy=()``.
         null_policy (str or list): see
@@ -118,7 +118,7 @@ class LASFile(object):
     Attributes:
         encoding (str or None): the character encoding used when reading the
             file in from disk
-            
+
     """
 
     def __init__(self, file_ref=None, **read_kwargs):

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -357,7 +357,10 @@ def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_data_comments="
             data section. See defaults.py READ_SUBS and NULL_SUBS for examples.
         ignore_data_comments (str): lines beginning with this character will be ignored
 
-    Returns: integer number of columns or -1 where they are different.
+    Returns: 
+        n_cols, regexp_subs: integer number of columns or -1 where they are different,
+        and the recommended set of regexp_subs (removing hyphen-replacing substitutions
+        when we find a hyphen in every line)
 
     """
 
@@ -365,10 +368,13 @@ def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_data_comments="
     title_line = file_obj.readline()
 
     item_counts = []
+    hyphen_exists = []
 
     for i, line in enumerate(file_obj):
         line_no = line_no + 1
         line = line.strip("\n").strip()
+        if "-" in line:
+            hyphen_exists.append(i)
         if line.strip().startswith(ignore_data_comments):
             continue
         else:
@@ -383,14 +389,25 @@ def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_data_comments="
             if (line_no == line_nos[1]) or (i >= 20):
                 break
 
+    if len(hyphen_exists) == len(item_counts):
+        logger.debug(f"Found a hyphen in every line of the sample data section ({len(item_counts)} lines)")
+        hyphen_sub_keys = defaults.HYPHEN_SUBS
+        hyphen_subs = []
+        for key in hyphen_sub_keys:
+            for sub in defaults.READ_SUBS[key]:
+                hyphen_subs.append(sub)
+        logger.trace_lasio(f'Removing {hyphen_subs}')
+        regexp_subs = [s for s in regexp_subs if not s in hyphen_subs]
+        logger.debug(f"Removed {hyphen_sub_keys} if present; recommending instead: {regexp_subs}")
+
     try:
         assert len(set(item_counts)) == 1
     except AssertionError:
         logger.debug("Inconsistent number of columns {}".format(item_counts))
-        return -1
+        return -1, regexp_subs
     else:
         logger.debug("Consistently found {} columns".format(item_counts[0]))
-        return item_counts[0]
+        return item_counts[0], regexp_subs
 
 
 def read_data_section_iterative_normal_engine(

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -357,7 +357,7 @@ def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_data_comments="
             data section. See defaults.py READ_SUBS and NULL_SUBS for examples.
         ignore_data_comments (str): lines beginning with this character will be ignored
 
-    Returns: 
+    Returns:
         n_cols, regexp_subs: integer number of columns or -1 where they are different,
         and the recommended set of regexp_subs (removing hyphen-replacing substitutions
         when we find a hyphen in every line)
@@ -390,15 +390,19 @@ def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_data_comments="
                 break
 
     if len(hyphen_exists) == len(item_counts):
-        logger.debug(f"Found a hyphen in every line of the sample data section ({len(item_counts)} lines)")
+        logger.debug(
+            f"Found a hyphen in every line of the sample data section ({len(item_counts)} lines)"
+        )
         hyphen_sub_keys = defaults.HYPHEN_SUBS
         hyphen_subs = []
         for key in hyphen_sub_keys:
             for sub in defaults.READ_SUBS[key]:
                 hyphen_subs.append(sub)
-        logger.trace_lasio(f'Removing {hyphen_subs}')
-        regexp_subs = [s for s in regexp_subs if not s in hyphen_subs]
-        logger.debug(f"Removed {hyphen_sub_keys} if present; recommending instead: {regexp_subs}")
+        logger.trace_lasio(f"Removing {hyphen_subs}")
+        regexp_subs = [s for s in regexp_subs if s not in hyphen_subs]
+        logger.debug(
+            f"Removed {hyphen_sub_keys} if present; recommending instead: {regexp_subs}"
+        )
 
     try:
         assert len(set(item_counts)) == 1

--- a/tests/examples/data_characters_numeric.las
+++ b/tests/examples/data_characters_numeric.las
@@ -1,0 +1,42 @@
+~Version Information
+VERS.             2.0 : CWLS log ASCII standard - Version 2.0
+WRAP.             NO  : One line per depth step
+#
+~Well Information Block
+#MNEM.UNIT                   Data Type:Information
+#__________________________________________________________
+  STRT.           2020-01-01 00:00:00 : START INDEX
+  STOP.           2020-01-01 00:00:01 : STOP INDEX
+  STEP.SEC           10.0000 : STEP
+  NULL.              -999.25 : NULL VALUE
+  COMP.                      : COMPANY
+  WELL.                      : WELL
+   FLD.                      : FIELD
+   LOC.                      : LOCATION
+  PROV.                      : PROVINCE
+  CNTY.                      : COUNTY
+  STAT.                      : STATE
+  CTRY.                      : COUNTRY
+  SRVC.                      : SERVICE COMPANY
+  DATE.                      : LOG DATE
+   UWI.                      : UNIQUE WELL ID
+   API.                      : API NUMBER
+#
+~Curve Information Block
+#MNEM.UNIT                     : Curve Description
+#---------                     --------------------
+TIME	    .HHMMSS	       :
+DATE	    .D		       :
+DEPT        .M                 : Bit Depth 2hz
+ARC_GR_UNC_RT.GAPI              : ARC Raw Gamma Ray, Real-Time
+#
+~Parameter Information Block
+#MNEM.UNIT                       Value:Description
+#__________________________________________________________
+#
+~Other Information Block
+
+#
+~A TIME        DATE       DEPT ARC_GR_UNC_RT
+00:00:00 2020-01-01  1500.2435        126.56
+00:00:01 2020-01-01  1500.3519        126.56

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -351,9 +351,11 @@ def test_data_characters_2():
     las = lasio.read(egfn("data_characters.las"))
     assert las["DATE"][0] == "01-Jan-20"
 
+
 def test_data_characters_numeric():
     las = lasio.read(egfn("data_characters_numeric.las"))
     assert las["DATE"][0] == "2020-01-01"
+
 
 def test_data_characters_types():
     from pandas.api.types import is_object_dtype

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -351,6 +351,9 @@ def test_data_characters_2():
     las = lasio.read(egfn("data_characters.las"))
     assert las["DATE"][0] == "01-Jan-20"
 
+def test_data_characters_numeric():
+    las = lasio.read(egfn("data_characters_numeric.las"))
+    assert las["DATE"][0] == "2020-01-01"
 
 def test_data_characters_types():
     from pandas.api.types import is_object_dtype


### PR DESCRIPTION
This change modifies defaults.py to add HYPHEN_SUBS - a list of those substitutions defined elsewhere in this file that look for and modify matches based on whether there is a hyphen. This is to discriminate between a substitution which works correctly for e.g.

```
123 12.350 1          123 12.350 1
125  6.120 2          125  6.120 2
127 -3.933 3   --->   127 -3.933 3
129-17.000 4          129 -17.000 4
129 -5.001 5          129 -5.001 5
```

but which falters badly on:

```
10:15:00 2018-05-22 17.34          10:15:00 2018 -05 -22 17.34
10:15:05 2018-05-22 22.14   --->   10:15:05 2018 -05 -22 22.14
10:15:10 2018-05-22 18.77          10:15:10 2018 -05 -22 18.77
```

It also modifies reader.py:inspect_data_section such that it

1. tracks whether a hyphen is found in each line of the data section (at least in the inspected part of the data section)
2. if there is, then it checks whether any of the above substitutions (i.e. defaults.py:HYPHEN_SUBS) have been included
3. if they have been, it returns a list of recommended substitutions i.e. all those requested minus those found in HYPHEN_SUBS

Finally las.py:LASFile.read is modified so that:

- it has a new keyword argument accept_regexp_sub_recommendations (default True)
- if the recommended substitutions returned by inspect_data_section is different to those requested, then if the above keyword argument is True, it should re-do the inspection with the recommended changes

As a result, parsing of dates such as '2018-05-22' should be vastly improved.

A number of docstrings have been unified for usability:

- ``__init__.py:read``
- ``las.py:LASFile.__init__``
- ``las.py:LASFile.read``

All existing tests are passing locally and one new test has been added which is also passing. It should also fix #529 