### PR TITLE
Formatting suggestions for improve_default_date

### DIFF
--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -93,7 +93,7 @@ def read(file_ref, **kwargs):
             The only reason you should use False is if speed is a very high priority
             and you had files with metadata that incorrectly indicates they are
             wrapped.
-        read_policy (str or list): Apply regular expression substitutions for common errors in      
+        read_policy (str or list): Apply regular expression substitutions for common errors in
                 fixed-width formatted data sections. If you do not want any such substitutions
                 to applied, pass ``read_policy=()``.
         null_policy (str or list): see
@@ -134,7 +134,7 @@ def read(file_ref, **kwargs):
             file for auto-detection of encoding.
             (this is handled by :func:`lasio.reader.open_with_codecs`)
 
-    
+
     Returns:
         a :class:`lasio.LASFile` object representing the file
 

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -67,7 +67,7 @@ class LASFile(object):
             The only reason you should use False is if speed is a very high priority
             and you had files with metadata that incorrectly indicates they are
             wrapped.
-        read_policy (str or list): Apply regular expression substitutions for common errors in      
+        read_policy (str or list): Apply regular expression substitutions for common errors in
                 fixed-width formatted data sections. If you do not want any such substitutions
                 to applied, pass ``read_policy=()``.
         null_policy (str or list): see
@@ -118,7 +118,7 @@ class LASFile(object):
     Attributes:
         encoding (str or None): the character encoding used when reading the
             file in from disk
-            
+
     """
 
     def __init__(self, file_ref=None, **read_kwargs):

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -357,7 +357,7 @@ def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_data_comments="
             data section. See defaults.py READ_SUBS and NULL_SUBS for examples.
         ignore_data_comments (str): lines beginning with this character will be ignored
 
-    Returns: 
+    Returns:
         n_cols, regexp_subs: integer number of columns or -1 where they are different,
         and the recommended set of regexp_subs (removing hyphen-replacing substitutions
         when we find a hyphen in every line)
@@ -390,15 +390,19 @@ def inspect_data_section(file_obj, line_nos, regexp_subs, ignore_data_comments="
                 break
 
     if len(hyphen_exists) == len(item_counts):
-        logger.debug(f"Found a hyphen in every line of the sample data section ({len(item_counts)} lines)")
+        logger.debug(
+            f"Found a hyphen in every line of the sample data section ({len(item_counts)} lines)"
+        )
         hyphen_sub_keys = defaults.HYPHEN_SUBS
         hyphen_subs = []
         for key in hyphen_sub_keys:
             for sub in defaults.READ_SUBS[key]:
                 hyphen_subs.append(sub)
-        logger.trace_lasio(f'Removing {hyphen_subs}')
-        regexp_subs = [s for s in regexp_subs if not s in hyphen_subs]
-        logger.debug(f"Removed {hyphen_sub_keys} if present; recommending instead: {regexp_subs}")
+        logger.trace_lasio(f"Removing {hyphen_subs}")
+        regexp_subs = [s for s in regexp_subs if s not in hyphen_subs]
+        logger.debug(
+            f"Removed {hyphen_sub_keys} if present; recommending instead: {regexp_subs}"
+        )
 
     try:
         assert len(set(item_counts)) == 1

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -351,9 +351,11 @@ def test_data_characters_2():
     las = lasio.read(egfn("data_characters.las"))
     assert las["DATE"][0] == "01-Jan-20"
 
+
 def test_data_characters_numeric():
     las = lasio.read(egfn("data_characters_numeric.las"))
     assert las["DATE"][0] == "2020-01-01"
+
 
 def test_data_characters_types():
     from pandas.api.types import is_object_dtype


### PR DESCRIPTION
#### Description:  Minor formatting suggestions to include in the improve_default_date branch

- Fix expected 2 blank lines[E302] for new test in test_read.py
- Remove eol-spaces from change code in __init__.py
- Remove eol-spaces from change code for las.py
- Apply Black to the changes in reader.py

Note: Applying Black to the changes in las.py caused some weird formatting in trying to reformat long lines.   The weird formatting looked harder to read than the long lines so I didn't include it in this pull-request. 