### PR TITLE
Maintenance for the ci-tests.yml file

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,13 +14,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, windows-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.6"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
- Update ci action versions per ci warnings.

- Update python 3.6 to be excluded from ubuntu-latest because python 3.6 is not an included cached tool on the latest Ubuntu and this causes the 3.6 builds to fail: 
- Current Ubuntu install: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md

- Failed to add 3.11 because its cchardet fails to build cchardet.cpp(196): fatal error C1083: Cannot open include file: 'longintrepr.h': No such file or directory.  This is a problem that will need to be resolved going forward.

- Add double-quotes around all the version numbers. From reading the documentation this seems to be the standard.

--
Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC