### PR TITLE
Update CITATION.cff for version v0.30

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,10 +9,10 @@ authors:
   - name: "Lasio contributors"
     website: "https://lasio.readthedocs.io/en/latest/contributing.html"
 repository-code: "https://github.com/kinverarity1/lasio"
-version: 0.29
-url: https://github.com/kinverarity1/lasio/releases/tag/v0.29
-commit: d2e0ca0c70bb4d5ef0a8e0a0b6a8e5df6639b09e
-date-released: 2021-04-14
+version: 0.30
+url: https://github.com/kinverarity1/lasio/releases/tag/v0.30
+commit: 357cec616fbcc7d47b5a77ea4087433b6e52acdc
+date-released: 2022-05-12
 license: MIT
 type: software
 


### PR DESCRIPTION
This change is just catching the Citation file up to the current v0.30 release.