### PR TITLE
Add importlib.metadata as option to get version

### DIFF
--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -1,9 +1,37 @@
-import subprocess, re
-from pkg_resources import get_distribution, DistributionNotFound
+import subprocess
+import re
+
+# from pkg_resources import get_distribution, DistributionNotFound
 from datetime import datetime
 import logging
 
 logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------------------
+# 01-20-2023:
+# - If importlib.metadata is available, then use it.
+# - Else use pgk_resources
+#
+# Python versions 3.8+ have importlib.metadata as a standard module.
+# So once 3.5, 3.6, and 3.7 are no-longer supported by Lasio
+# this code can be simplified to import importlib.metadata.
+# and importlib.metadata.version(__package__) to fully replace
+# las_version = get_distribution(__package__).version
+# ------------------------------------------------------------------------------
+metadata_available = False
+try:
+    import importlib.metadata
+    from importlib.metadata import PackageNotFoundError
+
+    metadata_available = True
+except ModuleNotFoundError as err:
+    logger.debug(err)
+    try:
+        from pkg_resources import get_distribution
+        from pkg_resources import DistributionNotFound as PackageNotFoundError
+    except ModuleNotFoundError as err:
+        logger.debug(err)
+        pass
 
 # d[year][month][day] example: 20200420
 ver_date = datetime.now().strftime("d%Y%m%d")
@@ -31,8 +59,11 @@ def version():
     """
 
     try:
-        las_version = get_distribution(__package__).version
-    except DistributionNotFound as err:
+        if metadata_available is True:
+            las_version = importlib.metadata.version(__package__)
+        else:
+            las_version = get_distribution(__package__).version
+    except PackageNotFoundError as err:
         logger.debug(err)
         pass
 


### PR DESCRIPTION
#### Description
This pull request attempts to address issue  #537: las_version.py uses pkg_resources which is now discouraged.

It tries to import importlib.metadata, if it can't then it falls back to pkg_resources.

Python versions 3.8+ has importlib.metadata as a standard module. Python 3.5, 3.6, and 3.7 still need pkg_resources.

In the future, once 3.5, 3.6, and 3.7 are no-longer supported by Lasio this code can be simplified to import `importlib.metadata` and `importlib.metadata.version(__package__)` to fully replace `las_version = get_distribution(__package__).version`

#### Test results
This change is still at 87% coverage, but adds a 5 missed staments to las_version.py

```
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             28      6    79%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             12      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 495     64    87%
lasio/las_items.py           220     30    86%
lasio/las_version.py          69     19    72%
lasio/reader.py              476     27    94%
lasio/writer.py              200      9    96%
----------------------------------------------
TOTAL                       1656    219    87%
Coverage XML written to file coverage.xml
```

--
Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC