### PR TITLE
Remove 3.6 from the python versions Lasio is actively tested with

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,10 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        exclude:
-          - os: ubuntu-latest
-            python-version: "3.6"
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -165,8 +165,8 @@ Testing
 -------
 
 Every time lasio's main branch is updated, automated tests are run using
-`GitHub Actions`_ on Python 3.6, 3.7, 3.8, 3.9 and 3.10 on Ubuntu and Windows.
-lasio may work on Python 3.3, 3.4, 3.5 but these are not regularly tested.
+`GitHub Actions`_ on Python 3.7, 3.8, 3.9 and 3.10 on Ubuntu and Windows.
+lasio may work on Python 3.3, 3.4, 3.5, 3.6 but these are not regularly tested.
 
 To run tests yourself:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ lasio - Log ASCII Standard (LAS) files in Python
 
 Read and write Log ASCII Standard files with Python.
 
-This is a Python 3.6+ package to read and write Log ASCII Standard
+This is a Python 3.7+ package to read and write Log ASCII Standard
 (LAS) files, used for borehole data such as geophysical, geological, or
 petrophysical logs. It's compatible with versions 1.2 and 2.0 of the LAS file
 specification, published by the `Canadian Well Logging Society`_. 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-lasio is written to be compatible with Python 3.6+. The best
+lasio is written to be compatible with Python 3.7+. The best
 way to install is using pip.
 
 .. code-block:: bash

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This pull request is to resolve #549 End Lasio support for Python 3.5 and 3.6.

Notes:
- It removes any stated support for 3.5 and 3.6 and moves them in to the list of Python versions that may work but are not actively tested with current versions of Lasio.

- The README.md is not updated because maybe it should continue to represent release `Version 0.30 (12 May 2022)` until there is a new release.

- Tests pass with the same stats as `main` branch.

- Docs successfully build.

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC