### PR TITLE
Display missing shell commands in installation doc

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -17,7 +17,7 @@ provide extra functionality if they are installed (`pandas`_,
 `cChardet`_ and/or `chardet`_, and `openpyxl`_). I
 recommend installing these with:
 
-.. code-block::
+.. code-block:: bash
 
     $ pip install "lasio[all]"
 
@@ -25,7 +25,7 @@ lasio is now installed.
 
 To upgrade to the latest PyPI version, use:
 
-.. code-block::
+.. code-block:: bash
 
     $ pip install --upgrade lasio
 
@@ -36,7 +36,7 @@ Installing via pip gets the latest release which has been published on
 `PyPI <https://pypi.org/project/lasio/>`__. If you want, you can install 
 the latest changes from `GitHub`_:
 
-.. code-block::
+.. code-block:: bash
 
     $ pip install https://github.com/kinverarity1/lasio/archive/master.zip
 


### PR DESCRIPTION
#### Description:

This is expected to fix missing shell commands in the installation.html in the lastest docs:
https://lasio.readthedocs.io/en/latest/installation.html

It adds the `bash` programming-language indicator as part of the sphinx code-block indicator.

#### Test Results:
This works on locally compiled docs. However, locally compiled docs without this change also correctly displayed the shell commands.  So this change will have to merge to main and then see if the shell commands are visible at https://lasio.readthedocs.io/en/latest/installation.html.

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC
