### PR TITLE
Issue 554: Enable DLM. TAB

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -56,10 +56,20 @@ def define_line_splitter(provisional_delimiter):
     return the one that is right for the data delmiter
 
     """
+    # Split on whitespace
+    # Split into non-space strings and strings within either double or single
+    # quotes
     sow_regex = re.compile(r"""([^\s"']+)|"([^"]*)"|'([^']*)'""")
+    # Split on tabs
+    # Split into non-tab strings and strings within either double or single
+    # quotes
+    sot_regex = re.compile(r"""([^\t"']+)|"([^"]*)"|'([^']*)'""")
 
     def split_on_whitespace(line):
         return sow_regex.findall(line)
+
+    def split_on_tabs(line):
+        return sot_regex.findall(line)
 
     def split_on_comma(line):
         return line.split(",")
@@ -67,6 +77,7 @@ def define_line_splitter(provisional_delimiter):
     splitters = {
         "SPACE": split_on_whitespace,
         "COMMA": split_on_comma,
+        "TAB": split_on_tabs,
     }
 
     return splitters[provisional_delimiter]

--- a/tests/examples/2.0/sample_2.0_tab_dlm.las
+++ b/tests/examples/2.0/sample_2.0_tab_dlm.las
@@ -1,0 +1,48 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+ DLM.                           TAB :   DELIMITING CHARACTER BETWEEN DATA COLUMNS
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1669.7500                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000	123.450	2550.000	0.450	123.450	123.450	110.200	105.600
+1669.875	123.450	2550.000	0.450	123.450	123.450	110.200	105.600
+1669.750	123.450	2550.000	0.450	123.450	123.450	110.200	105.600

--- a/tests/examples/3.0/sample_3.0_tab_dlm.las
+++ b/tests/examples/3.0/sample_3.0_tab_dlm.las
@@ -1,0 +1,226 @@
+~VERSION INFORMATION
+ VERS.                          3.0 : CWLS LOG ASCII STANDARD -VERSION 3.0
+ WRAP.                           NO : ONE LINE PER DEPTH STEP
+ DLM .                          TAB : DELIMITING CHARACTER BETWEEN DATA COLUMNS 
+# Acceptable delimiting characters: SPACE (default), TAB, OR COMMA.
+~Well Information
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+ STRT .M              1670.0000                : First Index Value
+ STOP .M              1669.7500                : Last Index Value 
+ STEP .M              -0.1250                  : STEP 
+ NULL .               -999.25                  : NULL VALUE
+ COMP .       ANY OIL COMPANY INC.             : COMPANY
+ WELL .       ANY ET AL 12-34-12-34            : WELL
+ FLD  .       WILDCAT                          : FIELD
+ LOC  .       12-34-12-34W5M                   : LOCATION
+ CTRY .       CA                               : COUNTRY
+ PROV .       ALBERTA                          : PROVINCE 
+ SRVC .       ANY LOGGING COMPANY INC.         : SERVICE COMPANY
+ DATE .       13/12/1986                       : LOG DATE  {DD/MM/YYYY}
+ UWI  .       100123401234W500                 : UNIQUE WELL ID
+ LIC  .       0123456                          : LICENSE NUMBER
+ API  .       12345678                         : API NUMBER
+ LATI.DEG                             34.56789 : Latitude  {F}
+ LONG.DEG                           -102.34567 : Longitude  {F}
+ GDAT .       NAD83                            : Geodetic Datum
+# Lat & Long can also be presented as:
+# LATI .       45.37? 12' 58"                   : X LOCATION
+# LONG .       13.22? 30' 09"                   : Y LOCATION
+ UTM  .                                        : UTM LOCATION
+
+~Log_Parameter
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      ---------------------------
+ RUNS.  2              : # of Runs for this well.
+ RUN[1].            1  : Run 1
+ RUN[2].            2  : Run 2
+
+#Parameters that are zoned.
+ NMAT_Depth[1].M  500,1500     : Neutron Matrix Depth interval {F}               
+ NMAT_Depth[2].M  1500,2500    : Neutron Matrix Depth interval {F}                                 
+ DMAT_Depth[1].M  500,1510     : Density Matrix Depth interval {F}                  
+ DMAT_Depth[2].M  1510,2510    : Density Matrix Depth interval {F}                  
+
+#Service Company specific Parameters
+ MATR .            SAND : Neutron Porosity Matrix          |  NMAT_Depth[1]
+ MATR .            LIME : Neutron Porosity Matrix          |  NMAT_Depth[2]
+ MDEN .KG/M3       2650 : Matrix Bulk Density              |  DMAT_Depth[1]    
+ MDEN .KG/M3       2710 : Matrix Bulk Density              |  DMAT_Depth[2]
+
+#Required Parameters
+#Run 1 Parameters
+ RUN_DEPTH.M      0, 1500  : Run 1 Depth Interval  {F}    | Run[1]       
+ RUN_DATE.     22/09/1998  : Run 1 date  {DD/MM/YYYY}     | Run[1]
+ DREF .                : Depth Reference (KB,DF,CB)       | RUN[1]       
+ EREF .M               : Elevation of Depth Reference     | RUN[1]       
+ TDL  .M               : Total Depth Logger               | RUN[1]       
+ TDD  .M               : Total Depth Driller              | RUN[1]       
+ CSGL .M               : Casing Bottom Logger             | RUN[1]       
+ CSGD .M               : Casing Bottom Driller            | RUN[1]       
+ CSGS .MM              : Casing Size                      | RUN[1]       
+ CSGW .KG/M            : Casing Weight                    | RUN[1]       
+ BS   .MM              : Bit Size                         | RUN[1]       
+ MUD  .                : Mud type                         | RUN[1]       
+ MUDS .                : Mud Source                       | RUN[1]       
+ MUDD .KG/M3           : Mud Density                      | RUN[1]       
+ MUDV .S               : Mud Viscosity (Funnel)           | RUN[1]       
+ FL   .CC              : Fluid Loss                       | RUN[1]       
+ PH   .                : PH                               | RUN[1]       
+ RM   .OHMM            : Resistivity of Mud               | RUN[1]       
+ RMT  .DEGC            : Temperature of Mud               | RUN[1]       
+ RMF  .OHMM            : Rest. of Mud Filtrate            | RUN[1]       
+ RMFT .DEGC            : Temp. of Mud Filtrate            | RUN[1]       
+ RMC  .OHMM            : Rest. of Mud Cake                | RUN[1]       
+ RMCT .DEGC            : Temp. of Mud Cake                | RUN[1]       
+ TMAX .DEGC            : Max. Recorded Temp.              | RUN[1]       
+ TIMC .                : Date/Time Circulation Stopped    | RUN[1]       
+ TIML .                : Date/Time Logger Tagged Bottom   | RUN[1]       
+ UNIT .                : Logging Unit Number              | RUN[1]       
+ BASE .                : Home Base of Logging Unit        | RUN[1]       
+ ENG  .                : Recording Engineer               | RUN[1]       
+ WIT  .                : Witnessed By                     | RUN[1]       
+
+#Run 2 Parameters
+ RUN_DEPTH.M    1500,2513  : Run 2 Depth Interval  {F}    | Run[2]         
+ RUN_DATE.     23/10/1998  : Run 2 date  {DD/MM/YYYY}     | Run[2]
+ DREF .                : Depth Reference (KB,DF,CB)       | RUN[2]       
+ EREF .M               : Elevation of Depth Reference     | RUN[2]       
+ TDL  .M               : Total Depth Logger               | RUN[2]       
+ TDD  .M               : Total Depth Driller              | RUN[2]       
+ CSGL .M               : Casing Bottom Logger             | RUN[2]       
+ CSGD .M               : Casing Bottom Driller            | RUN[2]       
+ CSGS .MM              : Casing Size                      | RUN[2]       
+ CSGW .KG/M            : Casing Weight                    | RUN[2]       
+ BS   .MM              : Bit Size                         | RUN[2]       
+ MUD  .                : Mud type                         | RUN[2]       
+ MUDS .                : Mud Source                       | RUN[2]       
+ MUDD .KG/M3           : Mud Density                      | RUN[2]       
+ MUDV .S               : Mud Viscosity (Funnel)           | RUN[2]       
+ FL   .CC              : Fluid Loss                       | RUN[2]       
+ PH   .                : PH                               | RUN[2]       
+ RM   .OHMM            : Resistivity of Mud               | RUN[2]       
+ RMT  .DEGC            : Temperature of Mud               | RUN[2]       
+ RMF  .OHMM            : Rest. of Mud Filtrate            | RUN[2]       
+ RMFT .DEGC            : Temp. of Mud Filtrate            | RUN[2]       
+ RMC  .OHMM            : Rest. of Mud Cake                | RUN[2]       
+ RMCT .DEGC            : Temp. of Mud Cake                | RUN[2]       
+ TMAX .DEGC            : Max. Recorded Temp.              | RUN[2]       
+ TIMC .                : Date/Time Circulation Stopped    | RUN[2]       
+ TIML .                : Date/Time Logger Tagged Bottom   | RUN[2]       
+ UNIT .                : Logging Unit Number              | RUN[2]       
+ BASE .                : Home Base of Logging Unit        | RUN[2]       
+ ENG  .                : Recording Engineer               | RUN[2]       
+ WIT  .                : Witnessed By                     | RUN[2]       
+ 
+~Log_Definition
+#MNEM.UNIT             LOG CODES                   CURVE DESCRIPTION
+#----------------     -----------              -------------------------
+# Format of value in data section F=float, E=0.00E00 S=string
+ DEPT .M                                       : DEPTH               {F} 
+ DT   .US/M           123 456 789              : SONIC TRANSIT TIME  {F} 
+ RHOB .K/M3           123 456 789              : BULK DENSITY        {F}
+ NPHI .V/V            123 456 789              : NEUTRON POROSITY    {F}       
+ SFLU .OHMM           123 456 789              : SHALLOW RESISTIVITY {F}
+ SFLA .OHMM           123 456 789              : SHALLOW RESISTIVITY {F}
+ ILM  .OHMM           123 456 789              : MEDIUM RESISTIVITY  {F}
+ ILD  .OHMM           123 456 789              : DEEP RESISTIVITY    {F}
+ YME  .PA             123 456 789              : YOUNGS MODULES      {E0.00E+00}
+ CDES .               123 456 789              : CORE DESCRIPTION    {S} 
+# A 2D array channel begins here. It has 5 elements.
+# value after A: is time spacing of this array element from first element.
+ NMR[1] .ms           123 456 789              : NMR Echo Array      {AF;0ms} 
+ NMR[2] .ms           123 456 789              : NMR Echo Array      {AF;5ms}          
+ NMR[3] .ms           123 456 789              : NMR Echo Array      {AF;10ms}          
+ NMR[4] .ms           123 456 789              : NMR Echo Array      {AF;15ms}          
+ NMR[5] .ms           123 456 789              : NMR Echo Array      {AF;20ms}          
+
+
+~Drilling_Definition 
+DEPT .ft              : depth                                {F}                                
+DIST .ft              : cummulative increment of drilling.   {F}                                
+HRS  .hour            : Hours of drilling                    {F}                                
+ROP  .ft/hr           : Rate of Penetration                  {F}                                
+WOB  .klb             : weight on bit                        {F}                                
+RPM  .RPM             : rotations per minute                 {F}                                
+TQ   .AMPS            : torque on bit in amps                {F}                                
+PUMP .psi             : Mud pump pressure                    {F}                                
+TSPM .SPM             : total strokes per minute             {F}                                
+GPM  .gal/min         : gallons per minute                   {F}                                
+ECD  .ppg             : effective circulation density        {F}                                
+TBR  .                : total barrels returned               {F}                                
+
+~Drilling_Data | Drilling_Definition
+322.02	1.02	0.0	24.0	3	59	111	1199	179	 879	8.73	39
+323.05	2.05	0.1	37.5	2	69	118	1182	175	 861	8.73	202
+
+~Core_Definition 
+ CORET.M                                : Core Top Depth     {F}
+ COREB.M                                : Core Bottom Depth  {F}
+ CDES .                                 : Core Description   {S}
+
+~Core_Data[1] | Core_Definition
+ 545.50	550.60	Long cylindrical hunk of rock
+ 551.20	554.90	Long broken hunk of rock
+ 575.00	595.00	Debris only 
+
+~Core_Data[2] | Core_Definition
+ 655.50	660.60	Long cylindrical hunk of rock
+ 661.20	664.90	Long broken hunk of rock
+ 675.00	695.00	Debris only 
+
+~Inclinometry_Definition
+MD.  M                                  : Measured Depth        {F}
+TVD. M                                  : True Vertical Depth   {F}
+AZIM.DEG                                : Borehole Azimuth      {F}
+DEVI.DEG                                : Borehole Deviation    {F}
+
+~Inclinometry_Data | Inclinometry_Definition
+0.00	0.00	290.00	0.00
+100.00	100.00	234.00	0.00
+200.00	198.34	284.86	1.43
+300.00	295.44	234.21	2.04
+400.00	390.71	224.04	3.93
+500.00	482.85	224.64	5.88
+600.00	571.90	204.39	7.41
+
+~Test_Definition
+ DST.                                   :DST Number
+ DTOP.M                                 :DST Top Depth      {F}
+ DBOT.M                                 :DST Bottom Depth   {F}
+ DDES.                                  :DST recovery Description
+ FSIP.KPAA                              :Final Shut in pressure  {F}
+ BLOWD.                                 :BLOW DESCRIPTION        {S}
+
+~Test_Data | Test_Definition
+ 1	1500	1505	TSTM	13243	Weak Blow                  
+ 2	2210	2235	Oil to surface	21451	Strong Blow
+ 3	2575	2589	Packer Failure	0	Blow Out
+
+
+~TOPS_Definition
+ TOPT.M                                : Top Top Depth     {F}
+ TOPB.M                                : Top Bottom Depth  {F}
+ TOPN.                                 : Top Name          {S}
+
+~TOPS_Data | TOPS_Definition
+ 545.50	602.00	Viking
+ 602.00	615.00	Colony
+ 615.00	655.00	Basal Quartz
+
+~Perforations_Definition
+ PERFT.M                                : Perforation Top Depth    {F}
+ PERFB.M                                : Perforation Bottom Depth {F}
+ PERFD.SHOTS/M                          : Shots per meter          {F}
+ PERFT.                                 : Charge Type              {S}
+
+~Perforations_Data | Perforations_Definition
+ 545.50	550.60	12	BIG HOLE
+ 551.20	554.90	12	BIG HOLE
+ 575.00	595.00	12	BIG HOLE
+
+
+~Log_Data | Log_Definition
+1670.000	123.450	2550.000	0.450	123.450	123.450	110.200	105.600	1.45E+12	DOLOMITE WI/VUGS	10	12	14	18	13
+1669.875	123.450	2550.000	0.450	123.450	123.450	110.200	105.600	1.47E+12	LIMESTOVE       	12	15	21	35	25
+1669.750	123.450	2550.000	0.450	123.450	123.450	110.200	105.600	2.85E+12	LOST INTERVAL   	18	25	10	8	17

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -487,10 +487,12 @@ def test_sample_dtypes_specified_as_false():
     assert isinstance(las.curves[2].data[0], str)
     assert isinstance(las.curves[3].data[0], str)
 
+
 def test_index_null_issue227():
     las = lasio.examples.open("index_null.las")
-    assert las['DEPT'].data[1] == 999.25
-    assert numpy.isnan(las['DT'].data[0])
+    assert las["DEPT"].data[1] == 999.25
+    assert numpy.isnan(las["DT"].data[0])
+
 
 def test_excess_curves():
     las = lasio.examples.open("excess_curves.las")
@@ -499,3 +501,15 @@ def test_excess_curves():
     assert len(las["ROP"]) == 2
     assert numpy.isnan(las["ROP"]).all()
     assert list(las.df().columns) == ["TVD", "VS", "GAMMA", "ROP", "TEMP"]
+
+
+def test_tab_dlm_normal_engine():
+    # GitHub Issue 554
+    las = lasio.examples.open("2.0/sample_2.0_tab_dlm.las", engine="normal")
+    assert las["DEPT"].data[1] == 1669.875
+
+
+def test_tab_dlm_numpy_engine():
+    # GitHub Issue 554
+    las = lasio.examples.open("2.0/sample_2.0_tab_dlm.las", engine="numpy")
+    assert las["DEPT"].data[1] == 1669.875

--- a/tests/test_read_30.py
+++ b/tests/test_read_30.py
@@ -6,6 +6,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import lasio
+import lasio.examples
 
 test_dir = os.path.dirname(__file__)
 
@@ -32,7 +33,7 @@ def test_read_v30_sample_standard_sections():
     Verify 'Curves' doesn't read 'Core_*' sections
     Verity 'Parameter' does read '~Log_Parameter'
     Verify 'Parameter' doesn't read 'Performations_*' sections
-    
+
     """
     las = lasio.read(stegfn("3.0", "sample_3.0.las"))
     assert las.curves.DEPT.unit == "M"
@@ -42,3 +43,15 @@ def test_read_v30_sample_standard_sections():
     assert "Log_Parameter" not in las.sections.keys()
     assert len(las.sections["Parameter"]) == 71
     assert las.sections["Perforations_Definition"][0].mnemonic == "PERFT:1"
+
+
+def test_read_v30_tab_dlm_normal_engine():
+    # GitHub Issue 554
+    las = lasio.examples.open("3.0/sample_3.0_tab_dlm.las", engine="normal")
+    assert las["DEPT"].data[1] == 1669.875
+
+
+def test_read_v30_tab_dlm_numpy_engine():
+    # GitHub Issue 554
+    las = lasio.examples.open("3.0/sample_3.0_tab_dlm.las", engine="numpy")
+    assert las["DEPT"].data[1] == 1669.875


### PR DESCRIPTION
#### Description:

This pull-request is to fix #554 [Reading las file with TAB DLM in ~version section result in KeyError: 'TAB'](https://github.com/kinverarity1/lasio/issues/554)

##### Changes
- Add a TAB aplitter to the line_splitters in lasio/reader.py
- Add tests to verify tab dlm data is parsed

#### Test results:
```
---------- coverage: platform darwin, python 3.10.9-final-0 ----------
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             28      6    79%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             12      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 495     64    87%
lasio/las_items.py           220     30    86%
lasio/las_version.py          54     14    74%
lasio/reader.py              470     19    96%
lasio/writer.py              200      9    96%
----------------------------------------------
TOTAL                       1635    206    87%
Coverage XML written to file coverage.xml
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC