### PR TITLE
Flake8 maintenance for test suite continued

### DIFF
--- a/tests/test_enhancements.py
+++ b/tests/test_enhancements.py
@@ -1,23 +1,30 @@
-import os, sys
+import os
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-import fnmatch
 from pprint import pformat
 
-import numpy
 import pytest
 import math
 
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
 import lasio
 import lasio.las_items
-from lasio import las, read, exceptions
-
+from lasio import read, exceptions
 
 test_dir = os.path.dirname(__file__)
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
-stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", vers, fn)
+
+def egfn(fn):
+    # egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+    return os.path.join(test_dir, "examples", fn)
+
+
+def stegfn(vers, fn):
+    # stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", vers, fn)
+    return os.path.join(test_dir, "examples", vers, fn)
 
 
 def test_autodepthindex():
@@ -26,6 +33,11 @@ def test_autodepthindex():
     f = read(egfn("autodepthindex_F.las"))
     ft = read(egfn("autodepthindex_FT.las"))
     err = read(egfn("autodepthindex_M_FT.las"))
+    assert m.index_unit == "M"
+    assert m_lower.index_unit == "M"
+    assert f.index_unit == "FT"
+    assert ft.index_unit == "FT"
+    assert err.index_unit is None
 
 
 def test_autodepthindex_inconsistent():
@@ -35,28 +47,28 @@ def test_autodepthindex_inconsistent():
 
 
 def test_autodepthindex_m():
-    l = read(egfn("autodepthindex_M.las"))
-    assert l.depth_ft[-1] * 0.3048 == l.index[-1]
+    las = read(egfn("autodepthindex_M.las"))
+    assert las.depth_ft[-1] * 0.3048 == las.index[-1]
 
 
 def test_autodepthindex_m_lower():
-    l = read(egfn("autodepthindex_M_lower.las"))
-    assert l.depth_ft[-1] * 0.3048 == l.index[-1]
+    las = read(egfn("autodepthindex_M_lower.las"))
+    assert las.depth_ft[-1] * 0.3048 == las.index[-1]
 
 
 def test_autodepthindex_f():
-    l = read(egfn("autodepthindex_F.las"))
-    assert l.depth_m[-1] / 0.3048 == l.index[-1]
+    las = read(egfn("autodepthindex_F.las"))
+    assert las.depth_m[-1] / 0.3048 == las.index[-1]
 
 
 def test_autodepthindex_ft():
-    l = read(egfn("autodepthindex_FT.las"))
-    assert l.depth_m[-1] / 0.3048 == l.index[-1]
+    las = read(egfn("autodepthindex_FT.las"))
+    assert las.depth_m[-1] / 0.3048 == las.index[-1]
 
 
 def test_autodepthindex_feet():
-    l = read(egfn("autodepthindex_FEET.las"))
-    assert l.depth_m[-1] / 0.3048 == l.index[-1]
+    las = read(egfn("autodepthindex_FEET.las"))
+    assert las.depth_m[-1] / 0.3048 == las.index[-1]
 
 
 def test_autodepthindex_point_one_inch():
@@ -69,40 +81,40 @@ def test_autodepthindex_point_one_inch():
 
 
 def test_df_indexing():
-    l = read(egfn("6038187_v1.2.las"))
+    las = read(egfn("6038187_v1.2.las"))
     metres = 9.05
-    spacing = l.well["STEP"].value
-    calc_index = math.floor((metres / spacing) - (l.well["STRT"].value / spacing))
+    spacing = las.well["STEP"].value
+    calc_index = math.floor((metres / spacing) - (las.well["STRT"].value / spacing))
     calc_index = int(calc_index)
-    assert l["GAMN"][calc_index] == l.df()["GAMN"][metres]
+    assert las["GAMN"][calc_index] == las.df()["GAMN"][metres]
 
 
 # TODO: make above test in reverse-ordered LAS (e.g. STRT > STOP)
 
 
 def test_df_reverse():
-    l = read(egfn("sample_rev.las"))
+    las = read(egfn("sample_rev.las"))
     metres = 1667
-    spacing = l.well["STEP"].value
-    calc_index = math.floor((metres // spacing) - (l.well["STRT"].value // spacing))
+    spacing = las.well["STEP"].value
+    calc_index = math.floor((metres // spacing) - (las.well["STRT"].value // spacing))
     calc_index = int(calc_index)
-    assert l["DT"][calc_index] == l.df()["DT"][metres]
+    assert las["DT"][calc_index] == las.df()["DT"][metres]
 
 
 def test_df_curve_names():
-    l = read(egfn("sample_rev.las"))
-    assert l.keys()[1:] == list(l.df().columns.values)
+    las = read(egfn("sample_rev.las"))
+    assert las.keys()[1:] == list(las.df().columns.values)
 
 
 def test_non_standard_section():
-    l = read(egfn("non-standard-header-section.las"))
-    assert "SPECIAL INFORMATION" in l.sections.keys()
+    las = read(egfn("non-standard-header-section.las"))
+    assert "SPECIAL INFORMATION" in las.sections.keys()
 
 
 def test_non_standard_sections():
-    l = read(egfn("non-standard-header-sections.las"))
-    assert "SPECIAL INFORMATION" in l.sections.keys()
-    assert "extra special information" in l.sections.keys()
+    las = read(egfn("non-standard-header-sections.las"))
+    assert "SPECIAL INFORMATION" in las.sections.keys()
+    assert "extra special information" in las.sections.keys()
 
 
 def test_repr():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,15 +1,17 @@
-import os, sys
+import os
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-import pytest
-import numpy as np
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored.
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import lasio.examples
 
 test_dir = os.path.dirname(__file__)
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
 
 
 def test_local_path():

--- a/tests/test_header_items.py
+++ b/tests/test_header_items.py
@@ -1,6 +1,9 @@
-import os, sys
+import os
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from pprint import pformat
 
@@ -13,9 +16,13 @@ import lasio.las_items
 
 test_dir = os.path.dirname(__file__)
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
 
-stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", vers, fn)
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
+
+
+def stegfn(vers, fn):
+    return os.path.join(test_dir, "examples", vers, fn)
 
 
 def test_repr():

--- a/tests/test_null_policy.py
+++ b/tests/test_null_policy.py
@@ -1,19 +1,23 @@
-import os, sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-import fnmatch
+import os
 
 import numpy
-import pytest
+
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from lasio import read
-from lasio import exceptions
 
 test_dir = os.path.dirname(__file__)
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
-stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", vers, fn)
+
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
+
+
+def stegfn(vers, fn):
+    return os.path.join(test_dir, "examples", vers, fn)
 
 
 def test_null_policy_NULL_default():  # should read as NaN

--- a/tests/test_open_file.py
+++ b/tests/test_open_file.py
@@ -1,30 +1,36 @@
-import os, sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
+import os
 
 import pytest
 
 # pathlib for python2 is installed via pip install -r requirements.txt
 from pathlib import Path
 
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
 from lasio import read
 
 test_dir = os.path.dirname(__file__)
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
 
 
 def test_open_pathlib_object():
-    l = read(Path(egfn("sample.las")))
+    las = read(Path(egfn("sample.las")))
+    assert type(las).__name__ == "LASFile"
 
 
 def test_open_url():
-    l = read(
+    las = read(
         "https://raw.githubusercontent.com/kinverarity1/"
         "lasio/master/standards/examples"
         "/1.2/sample_curve_api.las"
     )
+    assert type(las).__name__ == "LASFile"
 
 
 def test_open_url_different_newlines():
@@ -51,20 +57,24 @@ def test_open_url_different_newlines():
 
 def test_open_file_object():
     with open(egfn("sample.las"), mode="r") as f:
-        l = read(f)
+        las = read(f)
+        assert type(las).__name__ == "LASFile"
 
 
 def test_open_filename():
-    l = read(egfn("sample.las"))
+    las = read(egfn("sample.las"))
+    assert type(las).__name__ == "LASFile"
 
 
 def test_open_incorrect_filename():
     with pytest.raises(OSError):
-        l = read(egfn("sampleXXXDOES NOT EXIST.las"))
+        las = read(egfn("sampleXXXDOES NOT EXIST.las"))
+        # Should never get here because of the Exception
+        assert type(las).__name__ == "LASFile"
 
 
 def test_open_string():
-    l = read(
+    las = read(
         """~VERSION INFORMATION
  VERS.                  1.2:   CWLS LOG ASCII STANDARD -VERSION 1.2
  WRAP.                  NO:   ONE LINE PER DEPTH STEP
@@ -113,3 +123,4 @@ def test_open_string():
 1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
 """
     )
+    assert type(las).__name__ == "LASFile"


### PR DESCRIPTION
#### Description:

This change covers flake8 changes for about 1/3 of the test suite files.
- tests/test_open_file.py
- tests/test_null_policy.py
- tests/test_json.py
- tests/test_header_items.py
- tests/test_example.py
- tests/test_enhancements.py

This pull request makes changes suggested by [flake8](https://github.com/PyCQA/flake8).
These are mainly the same types of changes in the various files:
- Remove unused sys import (replaced by tests/__init__.py)
- Reorganize library and 3rd-party imports
- Remove other unused imports
- Convert path lambdas to functions
- Change ambiguously short variable names to something more descriptive
- Add additional asserts.  
  - Notes: 
  - Most times these are useful by adding a bit more information about what is being tested.  
  - A few times they don't add must to the test.


#### Test Results:

All test results continue to pass:

```
---------- coverage: python 3.10.9 -----------
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             28      6    79%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             12      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 495     64    87%
lasio/las_items.py           220     30    86%
lasio/las_version.py          69     23    67%
lasio/reader.py              470     19    96%
lasio/writer.py              200      9    96%
----------------------------------------------
TOTAL                       1650    215    87%
Coverage XML written to file coverage.xml



--------------------------------------------------- benchmark: 1 tests --------------------------------------------------
Name (time in ms)                 Min       Max      Mean  StdDev    Median     IQR  Outliers     OPS  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------
test_read_v12_sample_big     124.7772  131.6564  126.2386  2.2637  125.4748  1.1334       1;1  7.9215       8           1
-------------------------------------------------------------------------------------------------------------------------

```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC