### PR TITLE
Flake8 maintenance for test suite final set

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,20 +1,22 @@
-import os, sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-import fnmatch
-
-import numpy
-import pytest
+import os
 import pickle
 
-from lasio import las, read, exceptions
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+from lasio import read
 
 test_dir = os.path.dirname(__file__)
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
-stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", vers, fn)
+
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
+
+
+def stegfn(vers, fn):
+    return os.path.join(test_dir, "examples", vers, fn)
 
 
 def test_pickle_default_wb():

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,26 +1,29 @@
-import os, sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import glob
-import fnmatch
-import traceback
+import os
 import logging
 
-import numpy
-import pytest
+
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import lasio
 
 test_dir = os.path.dirname(__file__)
-
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
-stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", vers, fn)
-
 logger = logging.getLogger(__name__)
+
+
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
+
+
+def stegfn(vers, fn):
+    return os.path.join(test_dir, "examples", vers, fn)
 
 
 def read_file():
     las = lasio.read(stegfn("1.2", "sample_big.las"))
+    assert isinstance(las, lasio.LASFile)
 
 
 def test_read_v12_sample_big(benchmark):

--- a/tests/test_stack_curves.py
+++ b/tests/test_stack_curves.py
@@ -1,15 +1,17 @@
-import os, sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
+import os
 import pytest
 import numpy as np
-
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import lasio
 
 test_dir = os.path.dirname(__file__)
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
 
 
 def test_stack_curves_with_stub():

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,14 +1,14 @@
 # coding=utf-8
 
-import os, sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
+import os
 import re
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import lasio.las_version
 
 version_regex = re.compile(r"^\d+\.\d+")
-
-import lasio.las_version
 
 
 def test_non_existent_vcs_tool():

--- a/tests/test_wrapped.py
+++ b/tests/test_wrapped.py
@@ -1,25 +1,35 @@
-import os, sys
+import os
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from lasio import read
-
+from lasio import read, LASFile
 from lasio.reader import StringIO
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
-stegfn = lambda vers, fn: os.path.join(os.path.dirname(__file__), "examples", vers, fn)
+test_dir = os.path.dirname(__file__)
+
+
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
+
+
+def stegfn(vers, fn):
+    return os.path.join(test_dir, "examples", vers, fn)
 
 
 def test_wrapped():
     fn = egfn("1001178549.las")
-    l = read(fn)
+    las = read(fn)
+    assert isinstance(las, LASFile)
 
 
 def test_write_wrapped():
     fn = stegfn("1.2", "sample_wrapped.las")
-    l = read(fn)
+    las = read(fn)
     s = StringIO()
-    l.write(s, version=2.0, wrap=True, fmt="%.5f")
+    las.write(s, version=2.0, wrap=True, fmt="%.5f")
     s.seek(0)
     assert (
         s.read()
@@ -116,9 +126,9 @@ LSWB.      : 35 Flag -Limit SWB
 
 def test_write_unwrapped():
     fn = stegfn("1.2", "sample_wrapped.las")
-    l = read(fn)
+    las = read(fn)
     s = StringIO()
-    l.write(s, version=2, wrap=False, fmt="%.5f")
+    las.write(s, version=2, wrap=False, fmt="%.5f")
     s.seek(0)
     assert (
         s.read()

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,20 +1,23 @@
-import os, sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-import pytest
+import os
+import sys
 import numpy as np
+
+# 02-20-2023: dcs: leaving this commented out for now, in case it needs to be
+# restored. Remove after 05-2023
+# import sys
+# sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import lasio
 import lasio.examples
 from lasio import read
 from lasio.excel import ExcelConverter
-
 from lasio.reader import StringIO
 
 test_dir = os.path.dirname(__file__)
 
-egfn = lambda fn: os.path.join(os.path.dirname(__file__), "examples", fn)
+
+def egfn(fn):
+    return os.path.join(test_dir, "examples", fn)
 
 
 def test_write_sect_widths_12(capsys):
@@ -31,18 +34,18 @@ def test_write_to_filename():
 
 
 def test_write_sect_widths_12_curves():
-    l = read(egfn("sample_write_sect_widths_12.las"))
+    las = read(egfn("sample_write_sect_widths_12.las"))
     s = StringIO()
-    l.write(s, version=1.2)
+    las.write(s, version=1.2)
     for start in ("D.M ", "A.US/M ", "B.K/M3 ", "C.V/V "):
         s.seek(0)
         assert "\n" + start in s.read()
 
 
 def test_write_sect_widths_20_narrow():
-    l = read(egfn("sample_write_sect_widths_20_narrow.las"))
+    las = read(egfn("sample_write_sect_widths_20_narrow.las"))
     s = StringIO()
-    l.write(s, version=2)
+    las.write(s, version=2)
     s.seek(0)
     assert (
         s.read()
@@ -92,9 +95,9 @@ between 625 metres and 615 metres to be invalid.
 
 
 def test_write_sect_widths_20_wide():
-    l = read(egfn("sample_write_sect_widths_20_wide.las"))
+    las = read(egfn("sample_write_sect_widths_20_wide.las"))
     s = StringIO()
-    l.write(s, version=2)
+    las.write(s, version=2)
     s.seek(0)
     assert (
         s.read()
@@ -144,17 +147,17 @@ between 625 metres and 615 metres to be invalid.
 
 
 def test_write_sample_empty_params():
-    l = read(egfn("sample_write_empty_params.las"))
-    l.write(StringIO(), version=2)
+    las = read(egfn("sample_write_empty_params.las"))
+    las.write(StringIO(), version=2)
 
 
 def test_df_curve_addition_on_export():
-    l = read(egfn("sample.las"))
-    df = l.df()
+    las = read(egfn("sample.las"))
+    df = las.df()
     df["ILD_COND"] = 1000 / df.ILD
-    l.set_data_from_df(df, truncate=False)
+    las.set_data_from_df(df, truncate=False)
     s = StringIO()
-    l.write(s, version=2, wrap=False, fmt="%.5f")
+    las.write(s, version=2, wrap=False, fmt="%.5f")
     s.seek(0)
     assert (
         s.read()
@@ -204,24 +207,24 @@ between 625 meters and 615 meters to be invalid.
 
 
 def test_write_xlsx():
-    l = read(egfn("sample.las"))
-    e = ExcelConverter(l)
+    las = read(egfn("sample.las"))
+    e = ExcelConverter(las)
     xlsxfn = "test.xlsx"
     e.write(xlsxfn)
     os.remove(xlsxfn)
 
 
 def test_export_xlsx():
-    l = read(egfn("sample.las"))
+    las = read(egfn("sample.las"))
     xlsxfn = "test2.xlsx"
-    l.to_excel(xlsxfn)
+    las.to_excel(xlsxfn)
     os.remove(xlsxfn)
 
 
 def test_multi_curve_mnemonics_rewrite():
-    l = read(egfn("sample_issue105_a.las"))
+    las = read(egfn("sample_issue105_a.las"))
     s = StringIO()
-    l.write(s, version=2, wrap=False, fmt="%.5f")
+    las.write(s, version=2, wrap=False, fmt="%.5f")
     s.seek(0)
     assert (
         s.read()
@@ -267,9 +270,9 @@ between 625 meters and 615 meters to be invalid.
 
 
 def test_multi_curve_missing_mnemonics_rewrite():
-    l = read(egfn("sample_issue105_b.las"))
+    las = read(egfn("sample_issue105_b.las"))
     s = StringIO()
-    l.write(s, version=2, wrap=False, fmt="%.5f")
+    las.write(s, version=2, wrap=False, fmt="%.5f")
     s.seek(0)
     assert (
         s.read()
@@ -315,10 +318,10 @@ between 625 meters and 615 meters to be invalid.
 
 
 def test_write_units():
-    l = read(egfn("sample.las"))
-    l.curves[0].unit = "FT"
+    las = read(egfn("sample.las"))
+    las.curves[0].unit = "FT"
     s = StringIO()
-    l.write(s, version=2, wrap=False, fmt="%.5f")
+    las.write(s, version=2, wrap=False, fmt="%.5f")
     s.seek(0)
     assert (
         s.read()
@@ -422,17 +425,17 @@ def test_to_csv_specify_units():
 
 
 def test_rename_and_write_curve_mnemonic():
-    l = read(egfn("sample.las"))
-    for curve in l.curves:
+    las = read(egfn("sample.las"))
+    for curve in las.curves:
         if curve.mnemonic != "DEPT":
             curve.mnemonic = "New_" + curve.mnemonic
-    for curve in l.curves:
+    for curve in las.curves:
         print(
             "mnemonic=%s original_mnemonic=%s"
             % (curve.mnemonic, curve.original_mnemonic)
         )
     s = StringIO()
-    l.write(s, version=2)
+    las.write(s, version=2)
     s.seek(0)
     assert (
         s.read()


### PR DESCRIPTION
#### Description:

This change covers flake8 changes for the 2nd 3rd of the test suite files.
This is part of **Flake8 maintenance for test suite** https://github.com/kinverarity1/lasio/issues/561

When this pull-request merges, then  #561 can be considered resolved.

- tests/test_serialization.py
- tests/test_speed.py
- tests/test_stack_curves.py
- tests/test_version.py
- tests/test_wrapped.py
- tests/test_write.py

This pull request makes changes suggested by [flake8](https://github.com/PyCQA/flake8).
These are mainly the same types of changes in the various files:

- Remove unused sys import (replaced by tests/\_\_init__.py)
- Reorganize library and 3rd-party imports
- Remove other unused imports
- Convert path lambdas to functions
- Change ambiguously short variable names to something more descriptive
- Add additional asserts.

#### Flake8 Ignores:
Test data in test_write.py has lines with trailing white space. Test data in test_wrapped.py has lines with trailing white space and long lines.
Flake8 should be configured to ignore those lines. Below is the suggested configuration for a .flake8 file.

```ini
[flake8]
per-file-ignores =
    test_wrapped.py:W291,E501
    test_write.py:W291
```


#### Test Results:

las.py started reporting an additional miss (from 63 to 64) but I haven't identified the before and after diff yet.

```
----------------------------------------------
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             28      6    79%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             12      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 495     64    87%
lasio/las_items.py           220     30    86%
lasio/las_version.py          69     23    67%
lasio/reader.py              470     19    96%
lasio/writer.py              200      9    96%
----------------------------------------------
TOTAL                       1650    215    87%
Coverage XML written to file coverage.xml



--------------------------------------------------- benchmark: 1 tests --------------------------------------------------
Name (time in ms)                 Min       Max      Mean  StdDev    Median     IQR  Outliers     OPS  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------
test_read_v12_sample_big     124.3532  125.6853  125.1433  0.4513  125.2544  0.6507       2;0  7.9908       8           1
-------------------------------------------------------------------------------------------------------------------------

```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC