### PR TITLE
Flake8 maintenance: lasio/las.py - Option 2

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -11,7 +11,6 @@ import csv
 import json
 import logging
 import re
-import sys
 import traceback
 
 # get basestring in py3
@@ -34,7 +33,9 @@ import numpy as np
 # internal lasio imports
 
 from . import exceptions
-from .las_items import HeaderItem, CurveItem, SectionItems, OrderedDict
+
+# from .las_items import HeaderItem, CurveItem, SectionItems, OrderedDict
+from .las_items import CurveItem
 from . import defaults
 from . import reader
 from . import writer
@@ -152,7 +153,7 @@ class LASFile(object):
         accept_regexp_sub_recommendations=True,
         index_unit=None,
         dtypes="auto",
-        **kwargs
+        **kwargs,
     ):
         """Read a LAS file.
 
@@ -240,7 +241,8 @@ class LASFile(object):
 
             test_lidar = file_obj.read(4)
             if test_lidar == "LASF":
-                raise IOError("This is a LASer file (i.e. LiDAR data), not a Log ASCII Standard file")
+                err_msg = "This is a LASer file (i.e. LiDAR data), not a Log ASCII Standard file"
+                raise IOError(err_msg)
             else:
                 file_obj.seek(0)
 
@@ -271,8 +273,8 @@ class LASFile(object):
                 section_positions
             ):
                 section_type = reader.determine_section_type(section_title)
-                logger.debug(
-                    "Parsing {typ} section at lines {first_line}-{last_line} ({k} bytes) {title}".format(
+                tmpl = "Parsing {typ} section at lines {first_line}-{last_line} ({k} bytes) {title}"
+                logger.debug(tmpl.format(
                         typ=section_type,
                         title=section_title,
                         first_line=first_line + 1,
@@ -409,7 +411,9 @@ class LASFile(object):
                     )
 
                     if recommended_regexp_subs != regexp_subs and accept_regexp_sub_recommendations:
-                        logger.info(f"The read substitutions {defaults.HYPHEN_SUBS} have been removed as this file appears to contain hyphens.")
+                        logger.info(
+                                f"The read substitutions {defaults.HYPHEN_SUBS}"
+                                "have been removed as this file appears to contain hyphens.")
                         regexp_subs = recommended_regexp_subs
                         n_columns, recommended_regexp_subs = reader.inspect_data_section(
                             file_obj,
@@ -430,7 +434,16 @@ class LASFile(object):
                     if isinstance(dtypes, dict):
                         dtypes = [dtypes.get(c.mnemonic, float) for c in self.curves]
 
-                    # Notes see 2d9e43c3 and e960998f for 'try' background
+                    # ----------------------------------------------------------------------
+                    # Notes
+                    # see 2d9e43c3 and e960998f for 'try' background
+                    # 2023-03-03: dcs:
+                    #  With the addtion of "Exception" to "except Exception" the
+                    # "except KeybboardInterrupt" shouldn't be needed because
+                    # "except Exception" won't catch the KeyboardInterrupt exception
+                    # .. verify before removing, by Cntrl-C in the middle of loading a big
+                    # las file..
+                    # ----------------------------------------------------------------------
 
                     # Attempt to read the data section
                     if engine == "numpy":
@@ -438,9 +451,7 @@ class LASFile(object):
                             curves_data_gen = reader.read_data_section_iterative_numpy_engine(
                                 file_obj, (first_line, last_line)
                             )
-                        except KeyboardInterrupt:
-                            raise
-                        except:
+                        except Exception:
                             try:
                                 file_obj.seek(k)
                                 curves_data_gen = (
@@ -455,9 +466,7 @@ class LASFile(object):
                                         line_splitter=line_splitter,
                                     )
                                 )
-                            except KeyboardInterrupt:
-                                raise
-                            except:
+                            except Exception:
                                 raise exceptions.LASDataError(
                                     traceback.format_exc()[:-1]
                                     + " in data section beginning line {}".format(i + 1)
@@ -477,16 +486,17 @@ class LASFile(object):
                                     line_splitter=line_splitter,
                                 )
                             )
-                        except KeyboardInterrupt:
-                            raise
-                        except:
+                        except Exception:
                             raise exceptions.LASDataError(
                                 traceback.format_exc()[:-1]
                                 + " in data section beginning line {}".format(i + 1)
                             )
 
                     # Assign data to curves.
-                    data_assigned_to_curves = {curve_idx: False for curve_idx in range(len(self.curves))}
+                    data_assigned_to_curves = {
+                        curve_idx: False for curve_idx in range(len(self.curves))
+                    }
+
                     curve_idx = 0
                     curve_length = 0
                     for curve_arr in curves_data_gen:
@@ -532,9 +542,8 @@ class LASFile(object):
                 file_obj.close()
 
             # TODO: reimplement these warnings!!
-
-            ###### logger.warning("No data section (regexp='~A') found")
-            ###### logger.warning("No numerical data found inside ~A section")
+            # logger.warning("No data section (regexp='~A') found")
+            # logger.warning("No numerical data found inside ~A section")
 
         # Understand the depth/index unit.
 
@@ -652,19 +661,10 @@ class LASFile(object):
     def to_excel(self, filename):
         """Export LAS file to a Microsoft Excel workbook.
 
-        This function will raise an :exc:`ImportError` if ``openpyxl`` is not
-        installed.
-
         Arguments:
             filename (str): a name for the file to be created and written to.
 
         """
-        try:
-            import openpyxl
-        except ImportError:
-            pass
-        else:
-            from .excel import ExcelConverter
 
         from . import excel
 
@@ -698,7 +698,7 @@ class LASFile(object):
             opened_file = True
             file_ref = open(file_ref, "w")
 
-        if not "lineterminator" in kwargs:
+        if "lineterminator" not in kwargs:
             kwargs["lineterminator"] = "\n"
         writer = csv.writer(file_ref, **kwargs)
 
@@ -1020,7 +1020,7 @@ class LASFile(object):
 
         """
         df_values = np.vstack([df.index.values, df.values.T]).T
-        if (not "names" in kwargs) or (not kwargs["names"]):
+        if ("names" not in kwargs) or (not kwargs["names"]):
             kwargs["names"] = [df.index.name] + [
                 str(name) for name in df.columns.values
             ]
@@ -1062,10 +1062,11 @@ class LASFile(object):
             raise KeyError("{} not found in LAS curves.".format(missing))
 
         if sort_curves:
-            nat_sort = lambda x: [
+            # Sort the channel list by numbers in the element strings
+            # Example: ['CBP2', 'CBP1'] > ['CBP1', 'CBP2']
+            channels.sort(key=lambda x: [
                 int(i) if i.isdigit() else i for i in re.split(r"(\d+)", x)
-            ]
-            channels.sort(key=nat_sort)
+            ])
 
         indices = [keys.index(i) for i in channels]
         return self.data[:, indices]
@@ -1184,13 +1185,13 @@ class LASFile(object):
             ix = self.curves.keys().index(mnemonic)
         self.curves.pop(ix)
 
-    def update_curve(self, mnemonic=None, ix=None, data=False, unit=False, descr=False, value=False):
+    def update_curve(self, mnemonic=None, data=False, **kwargs):
         """Update a curve.
 
         Keyword Arguments:
-            ix (int): index of curve in LASFile.curves.
             mnemonic (str): mnemonic of curve.
             data (ndarray): new data array (False if no update desired)
+            ix (int): index of curve in LASFile.curves.
             unit (str): new value for unit (False if no update desired)
             descr (str): new description (False if no update desired)
             value (str/int/float etc): new value (False if no update desired)
@@ -1198,6 +1199,11 @@ class LASFile(object):
         The index takes precedence over the mnemonic.
 
         """
+        ix = kwargs.get("ix", None)
+        unit = kwargs.get("unit", False)
+        descr = kwargs.get("descr", False)
+        value = kwargs.get("value", False)
+
         if ix is None:
             ix = self.curves.keys().index(mnemonic)
         curve = self.curves[ix]
@@ -1229,6 +1235,7 @@ class Las(LASFile):
     Retained for backwards compatibility.
 
     """
+
     pass
 
 
@@ -1244,7 +1251,7 @@ class JSONEncoder(json.JSONEncoder):
                 else:
                     try:
                         d["metadata"][name] = section.dictview()
-                    except:
+                    except AttributeError:
                         for item in section:
                             d["metadata"][name].append(dict(item))
             for curve in obj.curves:


### PR DESCRIPTION
#### Description:

This change covers flake8 changes for one of the main  Lasio files: `las.py`
This is part of Flake8 maintenance for Lasio code https://github.com/kinverarity1/lasio/issues/564

#### Notes!
This Pull Request is the 2nd of two options!  Select one of the options and close the other.

This option (the 2nd option) resolves `las.py:1187:101: E501 line too long (101 > 100 characters)` **by moving unused parameters to kwargs in the `update_curves()` method.**

The first option is Flake8 maintenance: lasio/las.py - Option 1 #567
It resolved the same issue by removing unused parameters from the `update_curves()` method.

#### Changes made
- **las.py::update_curves params to kwargs**
- las.py move lambda into sort function
- las.py remove un-needed excel imports
- las.py fix empty 'except's
- las.py remove unused imports, fix Exceptions, shorten lines.

##### Changes suggested by [flake8](https://github.com/PyCQA/flake8).

```bash
las.py:14:1: F401 'sys' imported but unused
las.py:37:1: F401 '.las_items.HeaderItem' imported but unused
las.py:37:1: F401 '.las_items.SectionItems' imported but unused
las.py:37:1: F401 '.las_items.OrderedDict' imported but unused
las.py:243:101: E501 line too long (102 > 100 characters)
las.py:275:101: E501 line too long (105 > 100 characters)
las.py:412:101: E501 line too long (144 > 100 characters)
las.py:443:25: E722 do not use bare 'except'
las.py:460:29: E722 do not use bare 'except'
las.py:482:25: E722 do not use bare 'except'
las.py:489:101: E501 line too long (105 > 100 characters)
las.py:536:13: E266 too many leading '#' for block comment
las.py:537:13: E266 too many leading '#' for block comment
las.py:663:13: F401 'openpyxl' imported but unused
las.py:667:13: F401 '.excel.ExcelConverter' imported but unused
las.py:701:12: E713 test for membership should be 'not in'
las.py:1023:13: E713 test for membership should be 'not in'
las.py:1065:13: E731 do not assign a lambda expression, use a def
las.py:1187:101: E501 line too long (101 > 100 characters)
las.py:1247:21: E722 do not use bare 'except'
```

#### Test Results

These changes reduce the number of lines of code in las.py and reduce the number of missed statements.

```
----------------------------------------------
Name                       Stmts   Miss  Cover
----------------------------------------------
lasio/__init__.py             28      6    79%
lasio/convert_version.py      20     20     0%
lasio/defaults.py             12      0   100%
lasio/examples.py             42     10    76%
lasio/excel.py                88     34    61%
lasio/exceptions.py            6      0   100%
lasio/las.py                 488     57    88%
lasio/las_items.py           220     30    86%
lasio/las_version.py          69     23    67%
lasio/reader.py              470     19    96%
lasio/writer.py              200      9    96%
----------------------------------------------
TOTAL                       1643    208    87%
Coverage XML written to file coverage.xml

--------------------------------------------------- benchmark: 1 tests --------------------------------------------------
Name (time in ms)                 Min       Max      Mean  StdDev    Median     IQR  Outliers     OPS  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------
test_read_v12_sample_big     123.9254  125.2377  124.5981  0.4123  124.6210  0.5108       3;0  8.0258       8           1
-------------------------------------------------------------------------------------------------------------------------
```

--

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC