### PR TITLE
Add extras to test requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ import os
 
 EXTRA_REQS = ("pandas", "chardet", "openpyxl")
 TEST_REQS = (
-        "pytest>=3.6",
-        "pytest-cov",
-        "coverage",
-        "codecov",
-        "pytest-benchmark",
-        "black",
+    "pytest>=3.6",
+    "pytest-cov",
+    "coverage",
+    "codecov",
+    "pytest-benchmark",
+    "black",
 ) + EXTRA_REQS
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,16 @@ from setuptools import setup
 import os
 
 EXTRA_REQS = ("pandas", "chardet", "openpyxl")
-TEST_REQS = (
-    "pytest>=3.6",
-    "pytest-cov",
-    "coverage",
-    "codecov",
-    "pytest-benchmark",
-    "black",
+TEST_REQS = tuple(
+    [
+        "pytest>=3.6",
+        "pytest-cov",
+        "coverage",
+        "codecov",
+        "pytest-benchmark",
+        "black",
+    ]
+    + list(EXTRA_REQS)
 )
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,14 @@ from setuptools import setup
 import os
 
 EXTRA_REQS = ("pandas", "chardet", "openpyxl")
-TEST_REQS = tuple(
-    [
+TEST_REQS = (
         "pytest>=3.6",
         "pytest-cov",
         "coverage",
         "codecov",
         "pytest-benchmark",
         "black",
-    ]
-    + list(EXTRA_REQS)
-)
+) + EXTRA_REQS
 
 setup(
     name="lasio",


### PR DESCRIPTION
Note that tests don't run with `pip install -e .[test]` because some tests require openpyxl. Therefore, test requirements should be both these needed for tests (the existing tuple) and the extras as well.