### PR TITLE
Update docs with correct supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Read and write Log ASCII Standard files with Python.
 
-This is a Python 3.5+ package to read and write Log ASCII Standard
+This is a Python 3.7+ package to read and write Log ASCII Standard
 (LAS) files, used for borehole data such as geophysical, geological, or
 petrophysical logs. It's compatible with versions 1.2 and 2.0 of the LAS file
 specification, published by the [Canadian Well Logging

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: System :: Filesystems",
         "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
Small PR to update the PyPI classifiers and docs to show support for python 3.11.

On a related note, if you were to adopt the [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) recommended deprecation policy, it is now time to drop support for 3.7 and 3.8. I didn't do that as part of this PR though.