### PR TITLE
30% faster reads by removing unnecessary `file.tell()` calls

### DIFF
--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -297,7 +297,7 @@ def find_sections_in_file(file_obj):
         or line breaks.
 
     """
-    file_pos = int(file_obj.tell())
+    file_pos = 0
     starts = []
     ends = []
     line_no = -1
@@ -314,9 +314,10 @@ def find_sections_in_file(file_obj):
                 ends.append(line_no - 1)
 
     ends.append(line_no)
-    section_positions = []
-    for j, (file_pos, first_line_no, sline) in enumerate(starts):
-        section_positions.append((file_pos, first_line_no, ends[j], sline))
+    section_positions = [
+        (file_pos, first_line_no, ends[j], sline)
+        for j, (file_pos, first_line_no, sline) in enumerate(starts)
+    ]
     return section_positions
 
 
@@ -329,7 +330,11 @@ def full_line_length(line, file_obj):
         else file_obj.newlines[0]
     )
     newline_adjust = len(newlines) - 1 if newlines is not None else 0
-    return len(line) + newline_adjust
+    if line.endswith("\n"):
+        length = len(line) + newline_adjust
+    else:
+        length = len(line)
+    return length
 
 
 def determine_section_type(section_title):
@@ -602,6 +607,7 @@ def read_data_section_iterative_numpy_engine(file_obj, line_nos):
         names=None,
         unpack=True,
         loose=False,
+        dtype=float,
     )
 
     # If there is only one data row, np.genfromtxt treats it as one array of


### PR DESCRIPTION
Rather than calling `file.tell()` for every line while searching for section headers, call it only for lines containing a section header. This results in a _significant_ read performance boost of at least 30%.

| [Benchmark before](https://github.com/kinverarity1/lasio/actions/runs/5914132966/job/16039111154)  | [Benchmark after](https://github.com/emilykl/lasio/actions/runs/6113355365/job/16592688444) | Improvement |
| ------------- | ------------- | ------------- |
| 264ms  | 149ms  | 43% |

(This particular benchmark shows an even greater improvement but I was usually seeing values closer to 30% during local testing.)

This change is less straightforward than it seems, because we need to know the file position of the beginning of the header line; but calling `file.tell()` after reading that line gives us the file position of the beginning of the _following_ line.

This approach reverse-engineers the correct file position by observing that `file.tell()` seems to correspond to  subtracting the length of the current line, plus an adjustment depending on the file's line ending type (CRLF vs. LF).

Since the performance improvement is so large, I think this change is worth pursuing. However, there are two caveats:

- This approach _does not_ work reliably on files with mixed line endings.
  - As far as I can tell, Python provides no way of finding out the line ending _of a specific line_. `file_obj.newlines` only reveals which line endings have been encountered so far in the file.
  - [`test_open_url_different_newlines()`](https://github.com/emilykl/lasio/blob/41dc97316ae88a0dcff5c1f90c5bfcb389c7c920/tests/test_open_file.py#L37C22-L37C22) _happens_ to work because the header line has the same line ending as the first line in the file. Header lines which have a different line ending from the first line in the file will fail.

- And the more serious issue... `io.TextIOWrapper.tell()` officially returns "[an opaque number](https://docs.python.org/3/library/io.html#io.TextIOWrapper.tell)" which is guaranteed only to work as input to `io.TextIOWrapper.seek()`. So even though it seems to correspond to character count in practice, that's not officially documented and could change, making this a fragile approach.

Very open to comments and ideas! If there is a safer way to get the correct file position, without calling `file.tell()` for every line, I would love to implement it.