### PR TITLE
added version 1 to ORDER_DEFINITIONS

### DIFF
--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -44,6 +44,32 @@ def get_default_items():
 
 
 ORDER_DEFINITIONS = {
+    1.0: OrderedDict(
+        [
+            ("Version", ["value:descr"]),
+            (
+                "Well",
+                [
+                    "descr:value",
+                    (
+                        "value:descr",
+                        [
+                            "STRT",
+                            "STOP",
+                            "STEP",
+                            "NULL",
+                            "strt",
+                            "stop",
+                            "step",
+                            "null",
+                        ],
+                    ),
+                ],
+            ),
+            ("Curves", ["value:descr"]),
+            ("Parameter", ["value:descr"]),
+        ]
+    ),
     1.2: OrderedDict(
         [
             ("Version", ["value:descr"]),


### PR DESCRIPTION
- Version 1 LAS files have the same ORDER_DEFINITIONs as Version 1.2 LAS files.
- Currently Version 1 LAS files produce a key error.
- I propose adding Version 1 LAS files to the ORDER_DEFINITIONS, with the same definition as Version 1.2 LAS files, to allow support for this version.
