### PR TITLE
Remove print statement left in stack_curves method

### DIFF
--- a/lasio/las.py
+++ b/lasio/las.py
@@ -1055,7 +1055,6 @@ class LASFile(object):
             channels = list(mnemonic)
         else:
             raise TypeError("`mnemonic` argument must be string or sequence")
-        print(channels)
 
         if not set(keys).issuperset(set(channels)):
             missing = ", ".join(set(channels).difference(set(keys)))


### PR DESCRIPTION
A print statement was left in stack_curves method, printing to the console the list of all mnemonics to be stacked. And they can be thousands...