### PR TITLE
Upgrade imports to supported python versions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3
@@ -26,8 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install ".[all]"
-        pip install ".[test]"
+        pip install ".[all,test]"
     - name: Test with pytest
       run: |
         pytest

--- a/lasio/__init__.py
+++ b/lasio/__init__.py
@@ -3,6 +3,7 @@
 import logging
 import os
 
+
 def add_logging_level(levelName, levelNum, methodName=None):
     """Add a new logging level to current logger.
 
@@ -55,9 +56,9 @@ def add_logging_level(levelName, levelNum, methodName=None):
 
 add_logging_level("TRACE_LASIO", logging.DEBUG - 5, "trace_lasio")
 
-from .las_version import version
-from .las import LASFile, JSONEncoder
+from .las import JSONEncoder, LASFile
 from .las_items import CurveItem, HeaderItem, SectionItems
+from .las_version import version
 from .reader import open_file
 
 __version__ = version()

--- a/lasio/defaults.py
+++ b/lasio/defaults.py
@@ -4,7 +4,7 @@ import re
 
 import numpy as np
 
-from .las_items import HeaderItem, SectionItems, OrderedDict
+from .las_items import HeaderItem, OrderedDict, SectionItems
 
 
 def get_default_items():

--- a/lasio/examples.py
+++ b/lasio/examples.py
@@ -1,26 +1,8 @@
 import logging
 import os
-
-# Convoluted import for StringIO in order to support:
-#
-# - Python 3 - io.StringIO
-# - Python 2 (optimized) - cStringIO.StringIO
-# - Python 2 (all) - StringIO.StringIO
-
-try:
-    import cStringIO as StringIO
-except ImportError:
-    try:  # cStringIO not available on this system
-        import StringIO
-    except ImportError:  # Python 3
-        from io import StringIO
-    else:
-        from StringIO import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 from .las import LASFile
-
 
 logger = logging.getLogger(__name__)
 

--- a/lasio/las.py
+++ b/lasio/las.py
@@ -1,45 +1,18 @@
 """The main Lasio class: LASFile."""
 
-from __future__ import print_function
-
-try:  # will work in Python 3
-    from collections.abc import Sequence
-except ImportError:  # Support Python 2.7
-    from collections import Sequence
-
 import csv
 import json
 import logging
 import re
 import traceback
-
-# get basestring in py3
-
-try:
-    unicode = unicode
-except NameError:
-    # 'unicode' is undefined, must be Python 3
-    unicode = str
-    basestring = (str, bytes)
-else:
-    # 'unicode' exists, must be Python 2
-    bytes = str
-    basestring = basestring
-
-# Required third-party packages available on PyPi:
+from collections.abc import Sequence
 
 import numpy as np
 
-# internal lasio imports
-
-from . import exceptions
-
-# from .las_items import HeaderItem, CurveItem, SectionItems, OrderedDict
+from . import defaults, exceptions, reader, writer
 from .las_items import CurveItem
-from . import defaults
-from . import reader
-from . import writer
 
+basestring = (str, bytes)
 logger = logging.getLogger(__name__)
 
 

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -1,37 +1,11 @@
-import subprocess
-import re
-
-# from pkg_resources import get_distribution, DistributionNotFound
-from datetime import datetime
+import importlib.metadata
 import logging
+import re
+import subprocess
+from datetime import datetime
+from importlib.metadata import PackageNotFoundError
 
 logger = logging.getLogger(__name__)
-
-# ------------------------------------------------------------------------------
-# 01-20-2023:
-# - If importlib.metadata is available, then use it.
-# - Else use pgk_resources
-#
-# Python versions 3.8+ have importlib.metadata as a standard module.
-# So once 3.5, 3.6, and 3.7 are no-longer supported by Lasio
-# this code can be simplified to import importlib.metadata.
-# and importlib.metadata.version(__package__) to fully replace
-# las_version = get_distribution(__package__).version
-# ------------------------------------------------------------------------------
-metadata_available = False
-try:
-    import importlib.metadata
-    from importlib.metadata import PackageNotFoundError
-
-    metadata_available = True
-except ModuleNotFoundError as err:
-    logger.debug(err)
-    try:
-        from pkg_resources import get_distribution
-        from pkg_resources import DistributionNotFound as PackageNotFoundError
-    except ModuleNotFoundError as err:
-        logger.debug(err)
-        pass
 
 # d[year][month][day] example: 20200420
 ver_date = datetime.now().strftime("d%Y%m%d")
@@ -59,10 +33,7 @@ def version():
     """
 
     try:
-        if metadata_available is True:
-            las_version = importlib.metadata.version(__package__)
-        else:
-            las_version = get_distribution(__package__).version
+        las_version = importlib.metadata.version(__package__)
     except PackageNotFoundError as err:
         logger.debug(err)
         pass

--- a/lasio/reader.py
+++ b/lasio/reader.py
@@ -6,32 +6,12 @@ import re
 import sys
 import traceback
 import urllib.request
+from io import StringIO
 
 import numpy as np
 
-from . import defaults
-
-# Convoluted import for StringIO in order to support:
-#
-# - Python 3 - io.StringIO
-# - Python 2 (optimized) - cStringIO.StringIO
-# - Python 2 (all) - StringIO.StringIO
-
-try:
-    import cStringIO as StringIO
-except ImportError:
-    try:  # cStringIO not available on this system
-        import StringIO
-    except ImportError:  # Python 3
-        from io import StringIO
-    else:
-        from StringIO import StringIO
-else:
-    from StringIO import StringIO
-
-from . import exceptions
-from .las_items import HeaderItem, CurveItem, SectionItems, OrderedDict
-
+from . import defaults, exceptions
+from .las_items import CurveItem, HeaderItem, OrderedDict, SectionItems
 
 logger = logging.getLogger(__name__)
 

--- a/lasio/writer.py
+++ b/lasio/writer.py
@@ -1,13 +1,11 @@
 import logging
 import textwrap
+from copy import deepcopy
 
 import numpy as np
 
-from copy import deepcopy
-
-from .las_items import HeaderItem, CurveItem, SectionItems, OrderedDict
-from . import defaults
-from . import exceptions
+from . import defaults, exceptions
+from .las_items import CurveItem, HeaderItem, OrderedDict, SectionItems
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Python 3.9 is the lowest supported Python version. In this code, I've changed the imports to follow ruff's isort rules and remove the dance required for supporting Python 2 and Python 3 less than 3.9.

The unit tests pass on my local linux machine.

Hope this helps.